### PR TITLE
Removed orbital rotation

### DIFF
--- a/moldga/dga_main.py
+++ b/moldga/dga_main.py
@@ -65,9 +65,6 @@ def execute_dga_routine():
     g_dmft = comm.bcast(g_dmft, root=0)
     sigma_dmft = comm.bcast(sigma_dmft, root=0)
 
-    theta = 0
-    g_dmft = g_dmft.rotate_orbitals(theta=theta)
-
     logger.log_memory_usage("giwk & siwk", g_dmft, 2 * comm.size)
     logger.log_memory_usage("g2_dens & g2_magn", g2_dens, 2 * comm.size)
 
@@ -83,18 +80,16 @@ def execute_dga_routine():
         logger.log_info("Plotted g2 (dens) and g2 (magn).")
 
     ek = config.lattice.hamiltonian.get_ek(config.lattice.k_grid)
-    g_loc = GreensFunction.create_g_loc(sigma_dmft.create_with_asympt_up_to_core(), ek).rotate_orbitals(theta=theta)
-    sigma_dmft = sigma_dmft.rotate_orbitals(theta=theta)
+    g_loc = GreensFunction.create_g_loc(sigma_dmft.create_with_asympt_up_to_core(), ek)
+    sigma_dmft = sigma_dmft
     g_loc.save(output_dir=config.output.output_path, name="g_loc")
-    u_loc = config.lattice.hamiltonian.get_local_u().rotate_orbitals(theta=theta)
-    v_nonloc = config.lattice.hamiltonian.get_vq(config.lattice.q_grid).rotate_orbitals(theta=theta)
+    u_loc = config.lattice.hamiltonian.get_local_u()
+    v_nonloc = config.lattice.hamiltonian.get_vq(config.lattice.q_grid)
 
     logger.log_info("Preprocessing done.")
     logger.log_info("Starting local Schwinger-Dyson equation (SDE).")
 
     if comm.rank == 0:
-        g2_dens = g2_dens.rotate_orbitals(theta=theta)
-        g2_magn = g2_magn.rotate_orbitals(theta=theta)
         (gamma_d, gamma_m, chi_d, chi_m, vrg_d, vrg_m, f_d, f_m, gchi_d, gchi_m, sigma_loc) = (
             local_sde.perform_local_schwinger_dyson(g_loc, g2_dens, g2_magn, u_loc)
         )

--- a/moldga/four_point.py
+++ b/moldga/four_point.py
@@ -561,28 +561,6 @@ class FourPoint(IAmNonLocal, LocalFourPoint):
             self.frequency_notation,
         ).to_full_indices(self.original_shape)
 
-    def rotate_orbitals(self, theta: float = np.pi):
-        r"""
-        Rotates the orbitals of the four-point object around the angle :math:`\theta`. :math:`\theta` must be given in
-        radians and the number of orbitals needs to be 2. This is mainly for testing purposes.
-        """
-        copy = deepcopy(self)
-
-        if theta == 0:
-            return copy
-
-        if self.n_bands != 2:
-            raise ValueError("Rotating the orbitals is only allowed for objects that have two bands.")
-
-        r = np.array([[np.cos(theta), np.sin(theta)], [-np.sin(theta), np.cos(theta)]])
-        einsum_str = (
-            "ip,jq,rk,sl,xpqrs...->xijkl..."
-            if self.has_compressed_q_dimension
-            else "ip,jq,rk,sl,xyzpqrs...->xyzijkl..."
-        )
-        copy.mat = np.einsum(einsum_str, r.T, r.T, r, r, copy.mat, optimize=True)
-        return copy
-
     @staticmethod
     def load(
         filename: str,

--- a/moldga/greens_function.py
+++ b/moldga/greens_function.py
@@ -175,29 +175,6 @@ class GreensFunction(IAmNonLocal, LocalNPoint):
         niv_cut_range = np.arange(-niv_cut, niv_cut)
         return self.mat[..., self.niv + niv_cut_range[None, :] - wn[:, None]]
 
-    def rotate_orbitals(self, theta: float = np.pi):
-        r"""
-        Rotates the orbitals of the four-point object around the angle :math:`\theta`. :math:`\theta` must be given in
-        radians and the number of orbitals needs to be 2. Mainly intended for testing purposes.
-        """
-        copy = deepcopy(self)
-
-        if theta == 0:
-            return copy
-
-        r = np.array([[np.cos(theta), np.sin(theta)], [-np.sin(theta), np.cos(theta)]])
-
-        if len(self.current_shape) == 3:  # [o1,o2,v]
-            copy.mat = np.einsum("ip,qj,pqv->ijv", r.T, r, copy.mat, optimize=True)
-            return copy
-
-        if self.n_bands != 2:
-            raise ValueError("Rotating the orbitals is only allowed for objects that have two bands.")
-
-        einsum_str = "ip,qj,xpqv->xijv" if self.has_compressed_q_dimension else "ip,qj,xyzpqv->xyzijv"
-        copy.mat = np.einsum(einsum_str, r.T, r, copy.mat, optimize=True)
-        return copy
-
     def _get_fill_nonlocal(self) -> tuple[float, np.ndarray, np.ndarray]:
         """
         Returns the total filling, the k-mean of the occupation (shape [o1, o2]) and the occupation

--- a/moldga/interaction.py
+++ b/moldga/interaction.py
@@ -34,24 +34,6 @@ class LocalInteraction(IHaveMat, IHaveChannel):
 
         return LocalInteraction(np.einsum(permutation, self.mat, optimize=True), self.channel)
 
-    def rotate_orbitals(self, theta: float = np.pi):
-        r"""
-        Rotates the orbitals of the local interaction around the angle :math:`\theta`. :math:`\theta` must be given in
-        radians and the number of orbitals needs to be 2. This is mainly intended for testing purposes.
-        """
-        copy = deepcopy(self)
-
-        if theta == 0:
-            return copy
-
-        if self.n_bands != 2:
-            raise ValueError("Rotating the orbitals is only allowed for objects that have two bands.")
-
-        r = np.array([[np.cos(theta), np.sin(theta)], [-np.sin(theta), np.cos(theta)]])
-
-        copy.mat = np.einsum("ip,jq,rk,sl,pqrs->ijkl", r.T, r.T, r, r, copy.mat, optimize=True)
-        return copy
-
     def as_channel(self, channel: SpinChannel) -> "LocalInteraction":
         """
         Returns the spin combination for a given channel.
@@ -168,24 +150,6 @@ class Interaction(IAmNonLocal, LocalInteraction):
         return Interaction(
             np.einsum(permutation, self.mat, optimize=True), self.channel, self.nq, self.has_compressed_q_dimension
         )
-
-    def rotate_orbitals(self, theta: float = np.pi):
-        r"""
-        Rotates the orbitals of the interaction around the angle :math:`\theta`. :math:`\theta` must be given in
-        radians and the number of orbitals needs to be 2. Mostly intended for testing purposes.
-        """
-        copy = deepcopy(self)
-
-        if theta == 0:
-            return copy
-
-        if self.n_bands != 2:
-            raise ValueError("Rotating the orbitals is only allowed for objects that have two bands.")
-
-        r = np.array([[np.cos(theta), np.sin(theta)], [-np.sin(theta), np.cos(theta)]])
-
-        copy.mat = np.einsum("ip,jq,rk,sl,...pqrs->...ijkl", r.T, r.T, r, r, copy.mat, optimize=True)
-        return copy
 
     def as_channel(self, channel: SpinChannel) -> "Interaction":
         """

--- a/moldga/local_four_point.py
+++ b/moldga/local_four_point.py
@@ -615,24 +615,6 @@ class LocalFourPoint(LocalNPoint, IHaveChannel):
         copy.update_original_shape()
         return copy
 
-    def rotate_orbitals(self, theta: float = np.pi):
-        r"""
-        Rotates the orbitals of the four-point object around the angle :math:`\theta`. :math:`\theta` must be given in
-        radians and the number of orbitals needs to be 2. Mostly intended for testing purposes.
-        """
-        copy = deepcopy(self)
-
-        if theta == 0:
-            return copy
-
-        if self.n_bands != 2:
-            raise ValueError("Rotating the orbitals is only allowed for objects that have two bands.")
-
-        r = np.array([[np.cos(theta), np.sin(theta)], [-np.sin(theta), np.cos(theta)]])
-
-        copy.mat = np.einsum("ip,jq,rk,sl,pqrs...->ijkl...", r.T, r.T, r, r, copy.mat, optimize=True)
-        return copy
-
     @staticmethod
     def load(
         filename: str,

--- a/moldga/nonlocal_sde.py
+++ b/moldga/nonlocal_sde.py
@@ -37,15 +37,6 @@ def get_hartree_fock(
     hartree = 2 * (u_loc + v_q0).times("qabcd,dc->ab", config.sys.occ)
     fock = -1.0 / nq_tot * (u_loc + v_nonloc).compress_q_dimension().times("qadcb,qkdc->kab", occ_qk)
     hartree, fock = hartree[None, ..., None], fock[..., None]  # [k,o1,o2,v]
-
-    theta = 0
-
-    if theta == 0:
-        return hartree, fock
-
-    r = np.array([[np.cos(theta), np.sin(theta)], [-np.sin(theta), np.cos(theta)]])
-    hartree = np.einsum("ip,qj,xpqv->xijv", r.T, r, hartree, optimize=True)
-    fock = np.einsum("ip,qj,xpqv->xijv", r.T, r, fock, optimize=True)
     return hartree, fock
 
 
@@ -418,17 +409,12 @@ def calculate_self_energy_q(
         else [float(np.load(os.path.join(config.self_consistency.previous_sc_path, "mu_history.npy"))[-1])]
     )
 
-    theta = 0
-
     for current_iter in range(starting_iter + 1, starting_iter + config.self_consistency.max_iter + 1):
         logger.log_info("----------------------------------------")
         logger.log_info(f"Starting iteration {current_iter}.")
         logger.log_info("----------------------------------------")
 
-        giwk_full = GreensFunction.get_g_full(
-            sigma_old.rotate_orbitals(theta=-theta), mu_history[-1], config.lattice.hamiltonian.get_ek()
-        ).rotate_orbitals(theta=theta)
-
+        giwk_full = GreensFunction.get_g_full(sigma_old, mu_history[-1], config.lattice.hamiltonian.get_ek())
         giwk_full.save(output_dir=config.output.output_path, name="g_dga")
 
         logger.log_memory_usage("giwk", giwk_full, comm.size)
@@ -491,7 +477,7 @@ def calculate_self_energy_q(
         # This is done to minimize noise. We remove some fluctuations from dmft that are included in the local self-energy
         # calculated in this code and add the smooth dmft self-energy
         sigma_new += delta_sigma
-        sigma_new = sigma_new.concatenate_self_energies(sigma_dmft).rotate_orbitals(theta=-theta)
+        sigma_new = sigma_new.concatenate_self_energies(sigma_dmft)
 
         old_mu = mu_history[-1]
         if comm.rank == 0:

--- a/moldga/self_energy.py
+++ b/moldga/self_energy.py
@@ -200,25 +200,6 @@ class SelfEnergy(IAmNonLocal, LocalNPoint):
 
         return SelfEnergy(poly_mat, copy.nq, copy.full_niv_range, copy.has_compressed_q_dimension, False)
 
-    def rotate_orbitals(self, theta: float = np.pi):
-        r"""
-        Rotates the orbitals of the four-point object around the angle :math:`\theta`. :math:`\theta` must be given in
-        radians and the number of orbitals needs to be 2.
-        """
-        copy = deepcopy(self)
-
-        if theta == 0:
-            return copy
-
-        if self.n_bands != 2:
-            raise ValueError("Rotating the orbitals is only allowed for objects that have two bands.")
-
-        r = np.array([[np.cos(theta), np.sin(theta)], [-np.sin(theta), np.cos(theta)]])
-
-        einsum_str = "ip,qj,xpq...->xij..." if self.has_compressed_q_dimension else "ip,qj,xyzpq...->xyzij..."
-        copy.mat = np.einsum(einsum_str, r.T, r, copy.mat, optimize=True)
-        return copy
-
     def _estimate_niv_core(self, err: float = 1e-5):
         """
         Check when the real and the imaginary part are within an error margin of the asymptotic.

--- a/tests/test_four_point.py
+++ b/tests/test_four_point.py
@@ -263,31 +263,6 @@ def test_identity_shapes_and_like(rng):
     assert I2.num_vn_dimensions == target.num_vn_dimensions
 
 
-def test_rotate_orbitals_theta_zero_is_noop(small_fourpoint_compressed):
-    fp = small_fourpoint_compressed
-    out = fp.rotate_orbitals(theta=0.0)
-    assert np.allclose(out.mat, fp.mat)
-
-
-def test_rotate_orbitals_raises_if_not_two_bands(rng):
-    nq = (1, 1, 1)
-    o = 3
-    niw = 2
-    niv = 2
-    mat = rng.standard_normal((1, o, o, o, o, 2 * niw + 1, 2 * niv, 2 * niv)) + 1j * rng.standard_normal(
-        (1, o, o, o, o, 2 * niw + 1, 2 * niv, 2 * niv)
-    )
-    fp = FourPoint(
-        mat=mat,
-        nq=nq,
-        num_wn_dimensions=1,
-        num_vn_dimensions=2,
-        has_compressed_q_dimension=True,
-    )
-    with pytest.raises(ValueError):
-        _ = fp.rotate_orbitals(theta=np.pi / 4)
-
-
 def test_add_with_localinteraction_and_interaction(rng):
     nq = (4, 4, 1)
     qtot = 4


### PR DESCRIPTION
Removed orbital rotation, which was mainly introduced a few months back for testing & validation purposes. The functions are not needed anymore and - since they were always executed - save minor computation time.