### PR TITLE
Hide saving of Green's function behind flag.

### DIFF
--- a/moldga/dga_main.py
+++ b/moldga/dga_main.py
@@ -81,8 +81,10 @@ def execute_dga_routine():
 
     ek = config.lattice.hamiltonian.get_ek(config.lattice.k_grid)
     g_loc = GreensFunction.create_g_loc(sigma_dmft.create_with_asympt_up_to_core(), ek)
-    sigma_dmft = sigma_dmft
-    g_loc.save(output_dir=config.output.output_path, name="g_loc")
+
+    if comm.rank == 0:
+        g_loc.save(output_dir=config.output.output_path, name="g_loc")
+
     u_loc = config.lattice.hamiltonian.get_local_u()
     v_nonloc = config.lattice.hamiltonian.get_vq(config.lattice.q_grid)
 

--- a/moldga/nonlocal_sde.py
+++ b/moldga/nonlocal_sde.py
@@ -415,7 +415,9 @@ def calculate_self_energy_q(
         logger.log_info("----------------------------------------")
 
         giwk_full = GreensFunction.get_g_full(sigma_old, mu_history[-1], config.lattice.hamiltonian.get_ek())
-        giwk_full.save(output_dir=config.output.output_path, name="g_dga")
+
+        if comm.rank == 0:
+            giwk_full.save(output_dir=config.output.output_path, name="g_dga")
 
         logger.log_memory_usage("giwk", giwk_full, comm.size)
         gchi0_q = BubbleGenerator.create_generalized_chi0_q(


### PR DESCRIPTION
I noticed that the local and full Green's functions are saved to the same file by all MPI processes. I changed it now that only the root MPI process saves the file to the disk.