### PR TITLE
Added GPU support for SDE and chi0

### DIFF
--- a/moldga/bubble_gen.py
+++ b/moldga/bubble_gen.py
@@ -58,44 +58,107 @@ class BubbleGenerator:
         )
 
     @staticmethod
-    def create_generalized_chi0_q_fast(giwk: GreensFunction, niw: int, niv: int, q_list: np.ndarray) -> FourPoint:
-        r"""
-        Returns χ₀^{qν}_{abcd} = -β ∑ₖ G^{k}_{ad} G^{k-q}_{cb}
+    def create_generalized_chi0_q_cpu(giwk: GreensFunction, niw: int, niv: int, q_list: np.ndarray) -> FourPoint:
         """
-
+        Returns χ₀^{qν}_{abcd} = -β ∑ₖ G^{k}_{ad} G^{k-q}_{cb}
+        Optimized CPU version with preallocated buffers.
+        """
         wn = MFHelper.wn(niw, return_only_positive=True)
         nb = giwk.n_bands
         nq = len(q_list)
 
-        gchi0_q = np.zeros(
-            (nq, nb, nb, nb, nb, len(wn), 2 * niv),
-            dtype=giwk.mat.dtype,
-        )
+        gchi0_q = np.zeros((nq, nb, nb, nb, nb, len(wn), 2 * niv), dtype=giwk.mat.dtype)
 
         g_left = giwk.cut_niv(niv + niw).mat
         g_right = giwk.transpose_orbitals().cut_niv(niv + niw).mat
-        iv0 = niv + niw
-        g_left = g_left[..., iv0 - niv : iv0 + niv]
+        giwk_niv = g_right.shape[-1] // 2
+
+        g_r_buf = np.empty_like(g_left)
+        g_left = g_left[..., giwk_niv - niv : giwk_niv + niv]
 
         path, _ = np.einsum_path("xyzadv,xyzcbv->abcdv", g_left, g_left, optimize="optimal")
+        kxs, kys, kzs = np.arange(g_right.shape[0]), np.arange(g_right.shape[1]), np.arange(g_right.shape[2])
 
         for iq, q in enumerate(q_list):
-            g_r = g_right
-            g_r = np.take(g_r, np.arange(g_r.shape[0]) - q[0], axis=0, mode="wrap")
-            g_r = np.take(g_r, np.arange(g_r.shape[1]) - q[1], axis=1, mode="wrap")
-            g_r = np.take(g_r, np.arange(g_r.shape[2]) - q[2], axis=2, mode="wrap")
+            g_r_buf[...] = np.take(g_right, (kxs - q[0]) % g_right.shape[0], axis=0)
+            g_r_buf[...] = np.take(g_r_buf, (kys - q[1]) % g_right.shape[1], axis=1)
+            g_r_buf[...] = np.take(g_r_buf, (kzs - q[2]) % g_right.shape[2], axis=2)
 
             for iw, wn_i in enumerate(wn):
-                s = iv0 - niv - wn_i
-                e = iv0 + niv - wn_i
-
-                # Guaranteed: e - s == 2*niv
-                gchi0_q[iq, ..., iw, :] = np.einsum("xyzadv,xyzcbv->abcdv", g_left, g_r[..., s:e], optimize=path)
+                s = giwk_niv - niv - wn_i
+                e = giwk_niv + niv - wn_i
+                gchi0_q[iq, ..., iw, :] = np.einsum("xyzadv,xyzcbv->abcdv", g_left, g_r_buf[..., s:e], optimize=path)
 
         gchi0_q *= -config.sys.beta / config.lattice.q_grid.nk_tot
         return FourPoint(
             gchi0_q, SpinChannel.NONE, config.lattice.nq, 1, 1, full_niw_range=False, has_compressed_q_dimension=True
         )
+
+    @staticmethod
+    def create_generalized_chi0_q_gpu(giwk: GreensFunction, niw: int, niv: int, q_list: np.ndarray) -> FourPoint:
+        """
+        GPU version of χ₀^{qν}_{abcd} with preallocated buffers and fused einsum.
+        """
+        import cupy as cp
+
+        wn = MFHelper.wn(niw, return_only_positive=True)
+        nb = giwk.n_bands
+        nq = len(q_list)
+
+        gchi0_q = cp.zeros((nq, nb, nb, nb, nb, len(wn), 2 * niv), dtype=giwk.mat.dtype, order="F")
+
+        g_left = cp.asarray(giwk.cut_niv(niv + niw).mat, order="F")
+        g_right = cp.asarray(giwk.transpose_orbitals().cut_niv(niv + niw).mat, order="F")
+        giwk_niv = g_right.shape[-1] // 2
+
+        g_r_buf = cp.empty_like(g_left)
+        g_left = g_left[..., giwk_niv - niv : giwk_niv + niv]
+
+        kxs, kys, kzs = cp.arange(g_right.shape[0]), cp.arange(g_right.shape[1]), cp.arange(g_right.shape[2])
+
+        for iq, q in enumerate(q_list):
+            g_r_buf[...] = cp.take(g_right, (kxs - q[0]) % g_right.shape[0], axis=0)
+            g_r_buf[...] = cp.take(g_r_buf, (kys - q[1]) % g_right.shape[1], axis=1)
+            g_r_buf[...] = cp.take(g_r_buf, (kzs - q[2]) % g_right.shape[2], axis=2)
+
+            for iw, wn_i in enumerate(wn):
+                s = giwk_niv - niv - wn_i
+                e = giwk_niv + niv - wn_i
+                gchi0_q[iq, ..., iw, :] += cp.einsum("xyzadv,xyzcbv->abcdv", g_left, g_r_buf[..., s:e], optimize=True)
+
+        gchi0_q *= -config.sys.beta / config.lattice.q_grid.nk_tot
+        return FourPoint(
+            cp.asnumpy(gchi0_q),
+            SpinChannel.NONE,
+            config.lattice.nq,
+            1,
+            1,
+            full_niw_range=False,
+            has_compressed_q_dimension=True,
+        )
+
+    @staticmethod
+    def create_generalized_chi0_q_auto(mpi_distributor, giwk, niw, niv, q_list):
+        """
+        Automatically uses GPU if available, otherwise CPU.
+        """
+        logger = config.logger
+
+        try:
+            import cupy as cp
+
+            n_gpus = cp.cuda.runtime.getDeviceCount()
+
+            if cp.cuda.is_available() and n_gpus > 0:
+                logger.info(f"CuPy detected {n_gpus} GPU(s). Using GPU acceleration for gchi0_q calculation.")
+
+                gpu_id = mpi_distributor.my_rank % n_gpus
+                cp.cuda.Device(gpu_id).use()
+                return BubbleGenerator.create_generalized_chi0_q_gpu(giwk, niw, niv, q_list)
+        except ImportError:
+            pass
+
+        return BubbleGenerator.create_generalized_chi0_q_cpu(giwk, niw, niv, q_list)
 
     @staticmethod
     def create_generalized_chi0_pp_w0(g_loc: GreensFunction, niv_pp: int) -> LocalFourPoint:

--- a/moldga/nonlocal_sde.py
+++ b/moldga/nonlocal_sde.py
@@ -329,7 +329,7 @@ def calculate_sigma_from_kernel(kernel: FourPoint, giwk: GreensFunction, my_full
     return SelfEnergy(mat, config.lattice.nk, False).compress_q_dimension()
 
 
-def calculate_sigma_from_kernel_fast(
+def calculate_sigma_from_kernel_cpu(
     kernel: FourPoint,
     giwk: GreensFunction,
     my_full_q_list: np.ndarray,
@@ -372,57 +372,72 @@ def calculate_sigma_from_kernel_fast(
     return SelfEnergy(np.ascontiguousarray(mat), config.lattice.nk, False).compress_q_dimension()
 
 
-"""
-import cupy as cp
-import numpy as np
+def calculate_sigma_from_kernel_gpu(
+    kernel: FourPoint,
+    giwk: GreensFunction,
+    my_full_q_list: np.ndarray,
+) -> SelfEnergy:
+    r"""
+    Returns :math:`\Sigma_{ij}^{k} = -1/2 * 1/\beta * 1/N_q \sum_q [ U^q_{r;aibc} * K_{r;cbjd}^{qv} * G_{ad}^{w-v} ]`.
+    For very large momentum grids, this function is the slowest part compared to the rest of the code due to the
+    repeated loops. This function tries to execute it on the GPU using CuPy.
+    """
+    import cupy as cp
 
-
-def calculate_sigma_from_kernel_fast_gpu(
-    kernel: "FourPoint", giwk: "GreensFunction", my_full_q_list: np.ndarray
-) -> "SelfEnergy":
     nkx, nky, nkz = config.lattice.k_grid.nk
-    niv_core = config.box.niv_core
     nb = config.sys.n_bands
+    niv_core = config.box.niv_core
 
-    # Determine dtype (use complex64 if original is complex64, else complex128)
-    dtype = cp.complex64 if np.issubdtype(kernel.mat.dtype, np.complex64) else cp.complex128
-
-    # Allocate result on GPU
-    mat_gpu = cp.zeros((nkx, nky, nkz, nb, nb, niv_core), dtype=dtype)
-
-    # Frequency slices
+    mat_gpu = cp.zeros((nkx, nky, nkz, nb, nb, niv_core), dtype=kernel.mat.dtype, order="F")
     wn = MFHelper.wn(config.box.niw_core)
-    freq_slices = [slice(giwk.niv - w, giwk.niv - w + niv_core) for w in wn]
 
-    # Move arrays to GPU
-    giwk_gpu = cp.asarray(np.asfortranarray(giwk.mat), dtype=dtype)
-    kernel_gpu = cp.asarray(np.asfortranarray(kernel.to_full_niw_range().mat), dtype=dtype)
+    giwk_mat = cp.asarray(giwk.mat, order="F")
+    kernel_mat = cp.asarray(kernel.to_full_niw_range().mat, order="F")[..., niv_core:]
 
-    # Precompute k indices
     kxs, kys, kzs = cp.arange(nkx), cp.arange(nky), cp.arange(nkz)
     kx_indices = [((kxs + q[0]) % nkx) for q in my_full_q_list]
     ky_indices = [((kys + q[1]) % nky) for q in my_full_q_list]
     kz_indices = [((kzs + q[2]) % nkz) for q in my_full_q_list]
 
-    # Loop over q-points (memory-safe)
-    for idx_q in range(len(my_full_q_list)):
-        # Shifted giwk slice
-        g_q_view = giwk_gpu[
-            kx_indices[idx_q][:, None, None], ky_indices[idx_q][None, :, None], kz_indices[idx_q][None, None, :], ...
+    for iq in range(len(my_full_q_list)):
+        g_q_view = giwk_mat[
+            kx_indices[iq][:, None, None], ky_indices[iq][None, :, None], kz_indices[iq][None, None, :], ...
         ]
 
-        for idx_w, fs in enumerate(freq_slices):
-            g_slice = g_q_view[..., fs]  # shape: (xyz, o1, o2, niv_core)
-            k_slice = kernel_gpu[idx_q, ..., idx_w, niv_core:]  # shape: (o1,o2,o3,o4,v)
-            mat_gpu += cp.einsum("aijdv,xyzadv->xyzijv", k_slice, g_slice, optimize=True)
+        for iw, w in enumerate(wn):
+            g_slice = g_q_view[..., giwk.niv - w : giwk.niv + niv_core - w]
+            k_slice = kernel_mat[iq, ..., iw, :]
+            mat_gpu += cp.einsum("xyzadv,aijdv->xyzijv", g_slice, k_slice, optimize=True)
 
-    # Scale result
     mat_gpu *= -0.5 / config.sys.beta / config.lattice.q_grid.nk_tot
+    return SelfEnergy(np.ascontiguousarray(cp.asnumpy(mat_gpu)), config.lattice.nk, False).compress_q_dimension()
 
-    # Bring back to CPU and wrap as SelfEnergy
-    mat_cpu = cp.asnumpy(mat_gpu)
-    return SelfEnergy(np.ascontiguousarray(mat_cpu), config.lattice.nk, False).compress_q_dimension()
-"""
+
+def calculate_sigma_from_kernel_auto(
+    mpi_distributor: MpiDistributor, kernel: FourPoint, giwk: GreensFunction, my_full_q_list: np.ndarray
+) -> SelfEnergy:
+    """
+    Automatically tries to calculate the self-energy from the kernel on the GPU using CuPy. If CuPy is not installed
+    or no GPU is available, it falls back to the CPU implementation.
+    """
+    logger = config.logger
+
+    try:
+        import cupy as cp
+
+        n_gpus = cp.cuda.runtime.getDeviceCount()
+
+        if cp.cuda.is_available() and n_gpus > 0:
+            logger.info(f"CuPy detected {n_gpus} GPU(s). Using GPU acceleration for self-energy calculation.")
+
+            gpu_id = mpi_distributor.my_rank % n_gpus
+            cp.cuda.Device(gpu_id).use()
+            return calculate_sigma_from_kernel_gpu(kernel, giwk, my_full_q_list)
+    except ImportError:
+        # CuPy not installed
+        pass
+
+    return calculate_sigma_from_kernel_cpu(kernel, giwk, my_full_q_list)
 
 
 def get_starting_sigma(output_path: str, default_sigma: SelfEnergy) -> tuple[SelfEnergy, int]:
@@ -533,8 +548,8 @@ def calculate_self_energy_q(
             giwk_full.save(output_dir=config.output.output_path, name="g_dga")
 
         logger.log_memory_usage("giwk", giwk_full, comm.size)
-        gchi0_q = BubbleGenerator.create_generalized_chi0_q_fast(
-            giwk_full, config.box.niw_core, config.box.niv_full, my_irr_q_list
+        gchi0_q = BubbleGenerator.create_generalized_chi0_q_auto(
+            mpi_dist_irrk, giwk_full, config.box.niw_core, config.box.niv_full, my_irr_q_list
         )
 
         if config.eliashberg.perform_eliashberg:
@@ -579,7 +594,7 @@ def calculate_self_energy_q(
         kernel.mat = mpi_dist_fullbz.scatter(kernel.mat)
         logger.info("Kernel mapped to full BZ and scattered across all MPI ranks.")
 
-        sigma_new = calculate_sigma_from_kernel_fast(kernel, giwk_full, my_full_q_list)
+        sigma_new = calculate_sigma_from_kernel_auto(mpi_dist_fullbz, kernel, giwk_full, my_full_q_list)
         del kernel
         logger.info("Self-energy calculated from kernel.")
 

--- a/tests/test_nonlocal_sde_end_to_end.py
+++ b/tests/test_nonlocal_sde_end_to_end.py
@@ -1,4 +1,7 @@
+import contextlib
 import os
+import types
+from unittest import mock
 from unittest.mock import patch
 
 import numpy as np
@@ -23,8 +26,76 @@ def setup():
         yield folder, comm_mock
 
 
-@pytest.mark.parametrize("niw_core, niv_core, niv_shell", [(20, 20, 10)])
-def test_calculates_nonlocal_sde_correctly(setup, niw_core, niv_core, niv_shell):
+def make_cupy_mock():
+    cp = types.ModuleType("cupy")
+
+    cp.asarray = np.asarray
+    cp.zeros = np.zeros
+    cp.empty = np.empty
+    cp.empty_like = np.empty_like
+
+    cp.asnumpy = lambda x: x
+
+    cp.arange = np.arange
+    cp.take = np.take
+
+    def einsum(*args, **kwargs):
+        return np.einsum(*args, **kwargs)
+
+    cp.einsum = mock.Mock(side_effect=einsum)
+
+    cp.cuda = types.ModuleType("cupy.cuda")
+    cp.cuda.is_available = mock.Mock(return_value=True)
+
+    cp.cuda.runtime = types.ModuleType("cupy.cuda.runtime")
+    cp.cuda.runtime.getDeviceCount = mock.Mock(return_value=1)
+
+    class DummyDevice:
+        def __init__(self, device_id):
+            self.device_id = device_id
+
+        def use(self):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    cp.cuda.Device = DummyDevice
+
+    return cp
+
+
+@contextlib.contextmanager
+def gpu_cpu_context(use_gpu: bool):
+    mock_gpu = False
+    if use_gpu:
+        try:  # real GPU is available
+            import cupy as cp
+
+            yield mock_gpu
+        except ImportError:  # fallback to mocked GPU
+            mock_gpu = True
+            mock_cupy = make_cupy_mock()
+            with mock.patch.dict(
+                "sys.modules",
+                {
+                    "cupy": mock_cupy,
+                    "cupy.cuda": mock_cupy.cuda,
+                    "cupy.cuda.runtime": mock_cupy.cuda.runtime,
+                },
+            ):
+                yield mock_gpu
+                assert mock_cupy.einsum.called, "GPU path not taken (cp.einsum not called)"
+    else:  # force CPU path
+        with mock.patch.dict("sys.modules", {"cupy": None}):
+            yield mock_gpu
+
+
+@pytest.mark.parametrize("niw_core, niv_core, niv_shell, use_gpu", [(20, 20, 10, True), (20, 20, 10, False)])
+def test_calculates_nonlocal_sde_correctly(setup, niw_core, niv_core, niv_shell, use_gpu):
     folder, comm_mock = setup
 
     config.box.niw_core = niw_core
@@ -41,18 +112,17 @@ def test_calculates_nonlocal_sde_correctly(setup, niw_core, niv_core, niv_shell)
     u_loc = config.lattice.hamiltonian.get_local_u()
     v_nonloc = config.lattice.hamiltonian.get_vq(config.lattice.q_grid)
 
-    (gamma_d, gamma_m, chi_d, chi_m, vrg_d, vrg_m, f_d, f_m, gchi_d, gchi_m, s_loc) = (
-        local_sde.perform_local_schwinger_dyson(g_loc, g2_dens, g2_magn, u_loc)
-    )
+    (gamma_d, gamma_m, *_, s_loc) = local_sde.perform_local_schwinger_dyson(g_loc, g2_dens, g2_magn, u_loc)
 
-    sigma_dga = nonlocal_sde.calculate_self_energy_q(comm_mock, u_loc, v_nonloc, s_dmft, s_loc, gamma_d, gamma_m)
+    with gpu_cpu_context(use_gpu) as mock_gpu:
+        sigma_dga = nonlocal_sde.calculate_self_energy_q(comm_mock, u_loc, v_nonloc, s_dmft, s_loc, gamma_d, gamma_m)
 
     sigma_dga_mat = sigma_dga.decompress_q_dimension().mat
     sigma_dga_ref = np.load(f"{folder}/sigma_dga.npy")
 
-    assert np.allclose(sigma_dga_mat, sigma_dga_ref, atol=3e-5)
+    assert np.allclose(sigma_dga_mat, sigma_dga_ref, atol=3e-5 if not mock_gpu else 1e-3)
 
     sigma_interpolated_mat = sigma_dga.interpolate(12.5, 25, 30).mat
     sigma_interpolated_ref = np.load(f"{folder}/sigma_dga_interpolated.npy")
 
-    assert np.allclose(sigma_interpolated_mat, sigma_interpolated_ref, atol=3e-5)
+    assert np.allclose(sigma_interpolated_mat, sigma_interpolated_ref, atol=3e-5 if not mock_gpu else 1e-3)


### PR DESCRIPTION
Added a way to calculate the Schwinger-Dyson equation and the generalized bubble susceptibility on the GPU. These two steps are due to repeated loops by far the slowest ones and can be sped up by a significant factor. On my local machine, I was able to speed up the SDE by a factor of 4. The only concern might be memory constraints. Currently though on the VSC5, there are 2x A100 with 80GB memory each, so 160GB memory for the objects needed for both routines should suffice in almost all cases.