### PR TITLE
DGAmore.py and symmetrize_new.py are now added as executable scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ for single-core execution (mostly used for testing purposes) or
 ```bash
 mpiexec -np <n_proc> python DGAmore.py
 ```
-for multi-core processing with MPI. Instead of `mpiexec`, one can also use `mpirun` or `srun` (if you are using a 
+for multi-core processing with MPI. The entry point is added as an executable to the python environment and does not
+need the full path specified to run. Instead of `mpiexec`, one can also use `mpirun` or `srun` (if you are using a 
 slurm-based cluster). The number of processes, `<n_proc>`, should be chosen according to the size of the problem and the
 available computational resources.
 

--- a/dgamore/DGAmore.py
+++ b/dgamore/DGAmore.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # SPDX-FileCopyrightText: 2025-2026 Julian Peil <julian.peil@tuwien.ac.at>
 # SPDX-License-Identifier: MIT
 #

--- a/dgamore/symmetrize_new.py
+++ b/dgamore/symmetrize_new.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # SPDX-FileCopyrightText: 2025-2026 Julian Peil <julian.peil@tuwien.ac.at>
 # SPDX-License-Identifier: MIT
 #

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,6 @@ setup(
         "Operating System :: POSIX",
         "Operating System :: POSIX :: Linux",
     ],
+    scripts=["dgamore/DGAmore.py", "dgamore/symmetrize_new.py"],
     python_requires=">=3.12",
 )

--- a/tests/test_mpi_distributor.py
+++ b/tests/test_mpi_distributor.py
@@ -1,8 +1,8 @@
-"""Unit tests for dgamore.mpi_distributor.MpiDistributor.
-
-All MPI behaviour is provided by an in-process thread-based fake communicator
-(set up in conftest.py), so no MPI installation is required.
-"""
+# SPDX-FileCopyrightText: 2025-2026 Julian Peil <julian.peil@tuwien.ac.at>
+# SPDX-License-Identifier: MIT
+#
+# DGAmore — Multi-Orbital Ladder Dynamical Vertex Approximation (LDGA) &
+#           Eliashberg Equation Solver for Strongly Correlated Electron Systems
 
 import os
 

--- a/tests/test_mpi_utils.py
+++ b/tests/test_mpi_utils.py
@@ -1,9 +1,8 @@
-"""Unit tests for dgamore.mpi_utils.
-
-Uses the in-process thread-based fake MPI communicator; no MPI installation is
-required. Faked dgamore submodules (config, four_point, brillouin_zone,
-symmetry_reduction) supply the minimal surface the code touches.
-"""
+# SPDX-FileCopyrightText: 2025-2026 Julian Peil <julian.peil@tuwien.ac.at>
+# SPDX-License-Identifier: MIT
+#
+# DGAmore — Multi-Orbital Ladder Dynamical Vertex Approximation (LDGA) &
+#           Eliashberg Equation Solver for Strongly Correlated Electron Systems
 
 import numpy as np
 import pytest


### PR DESCRIPTION
DGAmore.py and symmetrize_new.py are now added as executable scripts to the environment after installing and do not require the full path for execution.
You can now directly start DGAmore.py after activating the python environment where DGAmore is installed.