### PR TITLE
Removed the q-grid setting and quantity in the code

### DIFF
--- a/dgamore/DGAmore.py
+++ b/dgamore/DGAmore.py
@@ -130,20 +130,10 @@ def main():
             f"{config.lattice.k_grid.nk_irr}/{config.lattice.k_grid.nk_tot} elements."
         )
 
-        if config.lattice.k_grid.nk == config.lattice.q_grid.nk:
-            config.lattice.q_grid = config.lattice.k_grid
-        else:
-            config.lattice.q_grid.specify_auto_symmetries(ek)
-
-        logger.info(
-            f"Automatically determined symmetries for the q-grid. The irreducible BZ has "
-            f"{config.lattice.q_grid.nk_irr}/{config.lattice.q_grid.nk_tot} elements."
-        )
-
     autodetect_memory_settings(comm)
 
     u_loc = config.lattice.hamiltonian.get_local_u()
-    v_nonloc = config.lattice.hamiltonian.get_vq(config.lattice.q_grid)
+    v_nonloc = config.lattice.hamiltonian.get_vq(config.lattice.k_grid)
 
     if comm.rank == 0:
         (
@@ -503,8 +493,6 @@ def main():
     logger.info("DGA routine finished.")
 
     if config.eliashberg.perform_eliashberg:
-        if not np.allclose(config.lattice.q_grid.nk, config.lattice.k_grid.nk):
-            raise ValueError("Eliashberg equation can only be solved when nq = nk.")
         logger.info("Starting with Eliashberg equation.")
         # sigma_dga is already saved to disk and never consumed by the Eliashberg step - drop the replicated
         # full-grid copy on every rank before the memory-heavy vertex construction
@@ -546,7 +534,7 @@ def autodetect_memory_settings(comm: MPI.Comm) -> None:
     Sets the four ``config.memory.save_memory_*`` switches automatically from the host memory available on every node
     the job runs on and an analytic estimate of the peak memory each affected operation consumes; the flag-less
     Schwinger-Dyson contraction (always the two-pass FFT path) is verified to fit as well. Must be called only after
-    the irreducible BZ is known (i.e. after auto-symmetry discovery), as the estimate depends on ``q_grid.nk_irr``.
+    the irreducible BZ is known (i.e. after auto-symmetry discovery), as the estimate depends on ``k_grid.nk_irr``.
 
     The budget is a **node total**: on a node with ``r`` ranks the memory held by all of them at a branch's peak is
     ``r * (baseline + distributed) + single`` (every rank holds the branch's persistent baseline; a *distributed*
@@ -584,8 +572,8 @@ def autodetect_memory_settings(comm: MPI.Comm) -> None:
     niv_cut = min(config.box.niw_core + config.box.niv_full + 10, config.box.niv_dmft)
     peaks = memory_estimator.estimate_peaks(
         n_bands=config.sys.n_bands,
-        nk_tot=config.lattice.q_grid.nk_tot,
-        nk_irr=config.lattice.q_grid.nk_irr,
+        nk_tot=config.lattice.k_grid.nk_tot,
+        nk_irr=config.lattice.k_grid.nk_irr,
         niw_core=config.box.niw_core,
         niv_core=config.box.niv_core,
         niv_full=config.box.niv_full,

--- a/dgamore/config.py
+++ b/dgamore/config.py
@@ -72,9 +72,9 @@ class BoxConfig:
 
 class LatticeConfig:
     """
-    Stores the lattice parameters: the symmetries, lattice type, input Hamiltonian and input interaction. The k and
-    q grids are built from the number of k/q points and the lattice symmetries. See ``dga_config.yaml`` or the
-    author's master's thesis for details.
+    Stores the lattice parameters: the symmetries, lattice type, input Hamiltonian and input interaction. The
+    momentum grid is built from the number of k-points and the lattice symmetries and is shared by the k- and
+    q-dependent quantities. See ``dga_config.yaml`` or the author's master's thesis for details.
 
     :ivar list symmetries: The lattice symmetries (a list of :class:`KnownSymmetries` or the auto sentinel).
     :ivar str type: How the kinetic Hamiltonian is provided (e.g. ``"from_wannier90"``).
@@ -84,11 +84,9 @@ class LatticeConfig:
     :ivar interaction_input: Path(s) to the interaction input.
     :vartype interaction_input: str | list
     :ivar tuple nk: Number of k-points per spatial direction.
-    :ivar tuple nq: Number of q-points per spatial direction (defaults to ``nk``).
     :ivar InteractionConfig interaction: The :class:`InteractionConfig`.
     :ivar Hamiltonian hamiltonian: The :class:`Hamiltonian` instance.
-    :ivar KGrid k_grid: The k-space :class:`KGrid`.
-    :ivar KGrid q_grid: The q-space :class:`KGrid`.
+    :ivar KGrid k_grid: The momentum-space :class:`KGrid`.
     """
 
     def __init__(self):
@@ -98,12 +96,10 @@ class LatticeConfig:
         self.interaction_type: str = "one_band_from_dmft"
         self.interaction_input: str | list = ""
         self.nk: tuple[int, int, int] = (16, 16, 1)
-        self.nq: tuple[int, int, int] = self.nk
 
         self.interaction: InteractionConfig = InteractionConfig()
         self.hamiltonian: Hamiltonian = Hamiltonian()
         self.k_grid: bz.KGrid = bz.KGrid(self.nk, self.symmetries)
-        self.q_grid: bz.KGrid = bz.KGrid(self.nq, self.symmetries)
 
 
 class SelfConsistencyConfig:

--- a/dgamore/config_parser.py
+++ b/dgamore/config_parser.py
@@ -119,8 +119,8 @@ class ConfigParser:
 
     def _build_lattice_config(self, config_file) -> LatticeConfig:
         """
-        Builds the lattice config from the ``lattice`` section (defaults if absent): grid sizes, symmetries, k/q grids,
-        and the lattice/interaction input.
+        Builds the lattice config from the ``lattice`` section (defaults if absent): grid size, symmetries, the
+        momentum grid, and the lattice/interaction input.
 
         :param config_file: The parsed YAML mapping.
         :return: The populated :class:`LatticeConfig`.
@@ -134,17 +134,13 @@ class ConfigParser:
 
         conf.nk = self._try_parse(section, "nk", conf.nk)
 
-        if "nq" not in section:
-            config.logger.info("'nq' not set in config. Setting 'nq' = 'nk'.")
-            conf.nq = conf.nk
-        else:
-            conf.nq = self._try_parse(section, "nq", conf.nq)
+        if "nq" in section:
+            config.logger.info("'nq' has been removed - the q-grid always equals the k-grid ('nk'); it is ignored.")
 
         symmetries = self._try_parse(section, "symmetries", "two_dimensional_square")
         conf.symmetries = bz.get_lattice_symmetries_from_string(symmetries)
 
         conf.k_grid = bz.KGrid(conf.nk, conf.symmetries)
-        conf.q_grid = bz.KGrid(conf.nq, conf.symmetries)
 
         conf.type = self._try_parse(section, "type", conf.type)
         conf.er_input = section["hr_input"]  # can be multiple types

--- a/dgamore/dga_config.yaml
+++ b/dgamore/dga_config.yaml
@@ -13,7 +13,6 @@ lattice:
   # (similar to how a wannier_hr.dat file is structured, but with 4 orbital indices).
   interaction_input: "" # Full path to the interaction file if interaction_type is 'custom', otherwise the interaction data will be taken from DMFT
   nk: [ 16, 16, 1 ] # Number of k-points in x, y and z-direction. Default: [ 16, 16, 1 ]
-  #nq: [ 16, 16, 1 ] # Number of q-points in x, y and z-direction. Default: [ 16, 16, 1 ]. If left empty, nq is set to nk
 
 self_consistency:
   max_iter: 20 # Maximum number of iterations

--- a/dgamore/dga_io.py
+++ b/dgamore/dga_io.py
@@ -99,7 +99,7 @@ def load_from_dmft_file_and_update_config() -> (
 
     output_format = "LDGA_Nk{}_Nq{}_wc{}_vc{}_vs{}".format(
         config.lattice.k_grid.nk_tot,
-        config.lattice.q_grid.nk_tot,
+        config.lattice.k_grid.nk_tot,
         config.box.niw_core,
         config.box.niv_core,
         config.box.niv_shell,
@@ -208,11 +208,9 @@ def set_hamiltonian(er_type: str, er_input: str | list, int_type: str, int_input
         ham, k_points = ham.read_hk_w2k(er_input)
         if config.lattice.nk is None:
             # ATTENTION: This is currently only available for 2D square lattices.
-            config.logger.info("Using q- and k-grid from wannier.hk file.")
+            config.logger.info("Using k-grid from wannier.hk file.")
             config.lattice.nk = (int(np.sqrt(k_points[:, 0].size)), int(np.sqrt(k_points[:, 0].size)), 1)
-            config.lattice.nq = config.lattice.nk
             config.lattice.k_grid = bz.KGrid(config.lattice.nk, config.lattice.symmetries)
-            config.lattice.q_grid = bz.KGrid(config.lattice.nq, config.lattice.symmetries)
         ham = ham.set_ek(ham.get_ek().reshape(*config.lattice.nk, config.sys.n_bands, config.sys.n_bands))
     else:
         raise NotImplementedError(f"Hamiltonian type {er_type} not supported.")

--- a/dgamore/eliashberg_solver.py
+++ b/dgamore/eliashberg_solver.py
@@ -10,7 +10,7 @@ non-local SDE step), this module assembles the particle-particle pairing vertex 
 :math:`\lambda \Delta = \pm\frac{1}{2\beta N_q}\, \Gamma^{pp}\, \chi_0^{pp}\, \Delta` with a matrix-free
 ARPACK/Lanczos eigensolver (two variants: an in-memory one and a memory-lean frequency-distributed one). The leading
 eigenvalue :math:`\lambda` signals the pairing instability and the eigenvector is the gap function
-:math:`\Delta(k, \nu)`. Requires ``nq == nk``. Equation numbers refer to the author's master's thesis (Chapter 4).
+:math:`\Delta(k, \nu)`. Equation numbers refer to the author's master's thesis (Chapter 4).
 """
 
 import os
@@ -126,7 +126,7 @@ def transform_vertex_q_frequencies_w0(f_q_r: FourPoint, niv_pp: int) -> FourPoin
     :return: The transformed vertex as a :class:`FourPoint` (pp notation, no bosonic axis, compressed q).
     """
     mat = _transform_vertex_frequencies_w0(f_q_r, niv_pp)
-    return FourPoint(mat, f_q_r.channel, config.lattice.q_grid.nk, 0, 2, True, True, True, FrequencyNotation.PP)
+    return FourPoint(mat, f_q_r.channel, config.lattice.k_grid.nk, 0, 2, True, True, True, FrequencyNotation.PP)
 
 
 # --- Full q-dependent vertex creation and transformation ---
@@ -370,7 +370,7 @@ def create_full_vertex_q_r_pp_w0_v2(
 
     logger.info(f"Loaded vrg_q_{gamma_r.channel.value} and chi_phys_q_{gamma_r.channel.value} from files.")
 
-    irrk_q_list = config.lattice.q_grid.get_irrq_list()
+    irrk_q_list = config.lattice.k_grid.get_irrq_list()
     my_irr_q_list = irrk_q_list[mpi_dist_irrk.my_slice]
 
     if config.eliashberg.save_fq:
@@ -411,7 +411,7 @@ def create_full_vertex_q_r_pp_w0_v2(
 
     if not config.eliashberg.save_fq:
         f_q_r = FourPoint(
-            f_q_r_mat, gamma_r.channel, config.lattice.q_grid.nk, 0, 2, False, True, True, FrequencyNotation.PP
+            f_q_r_mat, gamma_r.channel, config.lattice.k_grid.nk, 0, 2, False, True, True, FrequencyNotation.PP
         )
         logger.log_memory_usage(
             f"Full ladder-vertex ({f_q_r.channel.value})",
@@ -421,7 +421,7 @@ def create_full_vertex_q_r_pp_w0_v2(
         return f_q_r
 
     f_q_r = FourPoint(
-        f_q_r_mat, gamma_r.channel, config.lattice.q_grid.nk, 1, 2, False, True, True, FrequencyNotation.PP
+        f_q_r_mat, gamma_r.channel, config.lattice.k_grid.nk, 1, 2, False, True, True, FrequencyNotation.PP
     )
     logger.log_memory_usage(f"Full ladder-vertex ({f_q_r.channel.value})", f_q_r, mpi_dist_irrk.comm.size)
     f_q_r.mat = mpi_dist_irrk.gather(f_q_r.mat)
@@ -823,7 +823,7 @@ def solve_eliashberg_lanczos(
         allowed_ranks=ranks,
     )
 
-    gamma_r_pp = gamma_r_pp.map_to_full_bz(config.lattice.q_grid, config.lattice.q_grid.nk).decompress_q_dimension()
+    gamma_r_pp = gamma_r_pp.map_to_full_bz(config.lattice.k_grid, config.lattice.k_grid.nk).decompress_q_dimension()
     logger.log_memory_usage(f"Gamma_pp_{gamma_r_pp.channel.value}", gamma_r_pp, 1, allowed_ranks=ranks)
 
     sign = 1 if gamma_r_pp.channel == SpinChannel.SING else -1
@@ -845,7 +845,7 @@ def solve_eliashberg_lanczos(
     )
 
     n_bands = gamma_r_pp.n_bands
-    norm = 0.5 / config.lattice.q_grid.nk_tot / config.sys.beta
+    norm = 0.5 / config.lattice.k_grid.nk_tot / config.sys.beta
 
     chi0_mm = _chi0_to_matmul_layout(gchi0_q0_pp.mat)
     # The pairing vertex arrives in w2dynamics G2 leg order (c cdag c cdag), whereas _apply_gamma_pp expects the
@@ -969,7 +969,7 @@ def solve_eliashberg_lanczos_v2(
     )
 
     n_bands = gamma_r_pp.n_bands
-    norm = 0.5 / config.lattice.q_grid.nk_tot / config.sys.beta
+    norm = 0.5 / config.lattice.k_grid.nk_tot / config.sys.beta
 
     # Batched-matmul layout (see solve_eliashberg_lanczos): chi0 on the root rank (a view), the frequency-sliced
     # pairing vertex materialized once per rank; the flipped vertex is never stored (matvec reuses the direct array).
@@ -1117,9 +1117,9 @@ def solve(
     logger = config.logger
 
     mpi_dist_irrk = MpiDistributor.create_distributor(
-        ntasks=config.lattice.q_grid.nk_irr, comm=comm, name="Q", output_path=config.output.output_path
+        ntasks=config.lattice.k_grid.nk_irr, comm=comm, name="Q", output_path=config.output.output_path
     )
-    irrk_q_list = config.lattice.q_grid.get_irrq_list()
+    irrk_q_list = config.lattice.k_grid.get_irrq_list()
     my_irr_q_list = irrk_q_list[mpi_dist_irrk.my_slice]
 
     v_nonloc = v_nonloc.reduce_q(my_irr_q_list)
@@ -1207,7 +1207,7 @@ def solve(
         gamma_trip_pp.mat = mpi_dist_irrk.gather(gamma_trip_pp.mat, root=rank_trip)
 
         if mpi_dist_irrk.my_rank == rank_sing:
-            gchi0_q_pp = BubbleGenerator.create_generalized_chi0_q_pp_w0(giwk_dga, niv_pp, config.lattice.q_grid)
+            gchi0_q_pp = BubbleGenerator.create_generalized_chi0_q_pp_w0(giwk_dga, niv_pp, config.lattice.k_grid)
             logger.info("Created the bare bubble susceptibility in pp notation.", allowed_ranks=(rank_sing,))
 
         if mpi_dist_irrk.my_rank == rank_sing and mpi_dist_irrk.mpi_size > 1:
@@ -1236,7 +1236,7 @@ def solve(
 
         logger.info("Distributing Gamma_sing_pp along v equally to ranks/nodes.")
         gamma_sing_pp = mpi_utils.gather_full_ibz_for_vslice(
-            gamma_sing_pp, mpi_dist_irrk, mpi_dist_v, config.lattice.q_grid
+            gamma_sing_pp, mpi_dist_irrk, mpi_dist_v, config.lattice.k_grid
         )
         logger.info("Gamma_sing_pp distributed. Starting with singlet Lanczos solver.")
 
@@ -1251,7 +1251,7 @@ def solve(
             # calculating gchi0 in the full BZ only once
             # in the lanczos step only active_rank[0] will perform chi0 * delta due to memory reasons
             gchi0_q_pp = BubbleGenerator.create_generalized_chi0_q_pp_w0(
-                giwk_dga, niv_pp, config.lattice.q_grid
+                giwk_dga, niv_pp, config.lattice.k_grid
             ).decompress_q_dimension()
         else:
             gchi0_q_pp = None
@@ -1264,7 +1264,7 @@ def solve(
 
         logger.info("Distributing Gamma_trip_pp along v equally to ranks/nodes.")
         gamma_trip_pp = mpi_utils.gather_full_ibz_for_vslice(
-            gamma_trip_pp, mpi_dist_irrk, mpi_dist_v, config.lattice.q_grid
+            gamma_trip_pp, mpi_dist_irrk, mpi_dist_v, config.lattice.k_grid
         )
         logger.info("Gamma_trip_pp distributed. Starting with triplet Lanczos solver.")
 

--- a/dgamore/lambda_ops.py
+++ b/dgamore/lambda_ops.py
@@ -90,13 +90,13 @@ class LambdaCorrection:
         """
         lambda_start = LambdaCorrection.get_lambda_start(chi_r_mat)
         lambda_: float = lambda_start + delta
-        factor = 1 / config.sys.beta / config.lattice.q_grid.nk_tot
+        factor = 1 / config.sys.beta / config.lattice.k_grid.nk_tot
 
         for _ in range(maxiter):
             chi_lam = LambdaCorrection.apply_lambda(chi_r_mat, lambda_)
-            chir_sum = (config.lattice.q_grid.irrk_count[:, None] * chi_lam).sum() * factor
+            chir_sum = (config.lattice.k_grid.irrk_count[:, None] * chi_lam).sum() * factor
             f_lam = chir_sum - chi_r_loc_sum
-            fp_lam = -(config.lattice.q_grid.irrk_count[:, None] * chi_lam**2).sum() * factor
+            fp_lam = -(config.lattice.k_grid.irrk_count[:, None] * chi_lam**2).sum() * factor
             # NB: a vanishing fp_lam is intentional here - the resulting (inf) Newton step is what triggers the
             # delta-halving reset branch below, so it must NOT be guarded against.
             lambda_new = lambda_ - (f_lam / fp_lam).real
@@ -200,8 +200,8 @@ class LambdaCorrection:
             for channel in [SpinChannel.DENS, SpinChannel.MAGN]
         ]
 
-        chi_magn_loc_sum = (chi_dens_loc.mat + chi_magn_loc.mat).sum() - 1 / config.lattice.q_grid.nk_tot * (
-            config.lattice.q_grid.irrk_count[:, None, None, None, None, None] * chi_phys_q_dens.mat
+        chi_magn_loc_sum = (chi_dens_loc.mat + chi_magn_loc.mat).sum() - 1 / config.lattice.k_grid.nk_tot * (
+            config.lattice.k_grid.irrk_count[:, None, None, None, None, None] * chi_phys_q_dens.mat
         ).sum()
         chi_phys_q_r, lambda_r = LambdaCorrection.perform_single(chi_phys_q_r, chi_magn_loc_sum / config.sys.beta)
         logger.info(f"Lambda correction 'sp' applied. Lambda for magn channel is: {lambda_r:.6f}.")
@@ -530,7 +530,7 @@ class MultiOrbitalLambdaCorrection:
             and (ii) the determined mass matrix :math:`\Lambda_r`.
         """
         beta = config.sys.beta
-        q_grid = config.lattice.q_grid
+        q_grid = config.lattice.k_grid
         chi_r = chi_r.to_full_niw_range()
 
         # The complex128 susceptibility is cached on the irreducible wedge only (never inverted - the calibration
@@ -597,7 +597,7 @@ class MultiOrbitalLambdaCorrection:
         :return: The real array :math:`C_{r;a}`, shape ``[n_bands]``.
         """
         n_bands = chi_r.n_bands
-        q_grid = config.lattice.q_grid
+        q_grid = config.lattice.k_grid
         summed = chi_r.copy().to_full_niw_range().map_to_full_bz(q_grid).to_compound_indices().mat.sum(axis=(0, 1)) / (
             config.sys.beta * q_grid.nk_tot
         )

--- a/dgamore/mpi_utils.py
+++ b/dgamore/mpi_utils.py
@@ -892,7 +892,7 @@ def map_irrbz_fullbz(obj, mpi_dist_irrk, mpi_dist_fullbz):
     """
     obj.mat = mpi_dist_irrk.gather(obj.mat)
     if mpi_dist_irrk.comm.rank == 0:
-        obj = obj.map_to_full_bz(config.lattice.q_grid)
+        obj = obj.map_to_full_bz(config.lattice.k_grid)
     obj.mat = mpi_dist_fullbz.scatter(obj.mat)
     return obj
 
@@ -909,7 +909,7 @@ def exchange_and_map_irrbz_fullbz(
     over the full BZ (shape [q_full_rank, ...]), with symmetry-equivalent points correctly
     replicated according to the ``irrk_inv`` mapping.
 
-    If ``config.lattice.q_grid`` is in auto-discovered symmetry mode (its
+    If ``config.lattice.k_grid`` is in auto-discovered symmetry mode (its
     ``specify_auto_symmetries`` has been called), the per-k orbital transformation
     ``(sigma_k, U_k, conj_k)`` is also applied locally on each rank, using only the
     transformation arrays sliced to that rank's FBZ range. No global gather is needed.
@@ -932,7 +932,7 @@ def exchange_and_map_irrbz_fullbz(
     rank = comm.rank
     size = comm.size
 
-    q_grid = config.lattice.q_grid
+    q_grid = config.lattice.k_grid
 
     # 1. Global mapping setup
     # irrk_inv[fbz_idx] = irrbz_idx

--- a/dgamore/nonlocal_sde.py
+++ b/dgamore/nonlocal_sde.py
@@ -76,7 +76,7 @@ def get_hartree_fock(
 
     nb = config.sys.n_bands
     nk_tot = np.prod(config.lattice.nk)
-    nq_tot = np.prod(config.lattice.nq)
+    nq_tot = np.prod(config.lattice.nk)
 
     uq = (u_loc + v_nonloc.reduce_q(q_list)).permute_orbitals("abcd->adcb")  # (nq,a,d,c,b)
 
@@ -194,7 +194,7 @@ def create_auxiliary_chi_r_q_sum_v2(
     :param mpi_dist_irrq: MPI distributor over the irreducible BZ q-points (see :class:`MpiDistributor`).
     :return: The frequency-summed auxiliary susceptibility :math:`\sum_{\nu'}\chi^{*;q}_{r}` as a :class:`FourPoint`.
     """
-    irrk_q_list = config.lattice.q_grid.get_irrq_list()
+    irrk_q_list = config.lattice.k_grid.get_irrq_list()
     my_irr_q_list = irrk_q_list[mpi_dist_irrq.my_slice]
     chi_r_q_sum_mat = np.zeros_like(gchi0_q_inv.mat)
 
@@ -205,7 +205,7 @@ def create_auxiliary_chi_r_q_sum_v2(
             .invert_and_sum_over_last_vn(config.sys.beta)
             .mat
         )
-    return FourPoint(chi_r_q_sum_mat, gamma_r.channel, config.lattice.nq, 1, 1, False, has_compressed_q_dimension=True)
+    return FourPoint(chi_r_q_sum_mat, gamma_r.channel, config.lattice.nk, 1, 1, False, has_compressed_q_dimension=True)
 
 
 def create_auxiliary_chi_r_q_sum_v3(
@@ -229,7 +229,7 @@ def create_auxiliary_chi_r_q_sum_v3(
     :param mpi_dist_irrq: MPI distributor over the irreducible BZ q-points (see :class:`MpiDistributor`).
     :return: The frequency-summed auxiliary susceptibility :math:`\sum_{\nu'}\chi^{*;q}_{r}` as a :class:`FourPoint`.
     """
-    irrk_q_list = config.lattice.q_grid.get_irrq_list()
+    irrk_q_list = config.lattice.k_grid.get_irrq_list()
     my_irr_q_list = irrk_q_list[mpi_dist_irrq.my_slice]
     chi_r_q_sum_mat = np.zeros_like(gchi0_q_inv.mat)
 
@@ -240,7 +240,7 @@ def create_auxiliary_chi_r_q_sum_v3(
             .invert_and_sum_over_last_vn_v2(config.sys.beta)
             .mat
         )
-    return FourPoint(chi_r_q_sum_mat, gamma_r.channel, config.lattice.nq, 1, 1, False, has_compressed_q_dimension=True)
+    return FourPoint(chi_r_q_sum_mat, gamma_r.channel, config.lattice.nk, 1, 1, False, has_compressed_q_dimension=True)
 
 
 def create_vrg_r_q(gchi_aux_q_r_sum: FourPoint, gchi0_q_inv: FourPoint) -> FourPoint:
@@ -456,7 +456,7 @@ def perform_ornstein_zernike_fit(chi_phys_q_r: FourPoint) -> None:
         return opt.curve_fit(oz_spin_w0, q_grid, mat, p0=initial_guess)[0]
 
     chi = chi_phys_q_r.copy()
-    chi_mat = chi.map_to_full_bz(config.lattice.q_grid).to_half_niw_range().take_first_wn().mat.real
+    chi_mat = chi.map_to_full_bz(config.lattice.k_grid).to_half_niw_range().take_first_wn().mat.real
     orb_shape = (config.sys.n_bands,) * 4
     oz_coeffs = np.zeros(orb_shape + (2,), dtype=float)
     failed_orbitals = []
@@ -464,7 +464,7 @@ def perform_ornstein_zernike_fit(chi_phys_q_r: FourPoint) -> None:
     for idx in np.ndindex(orb_shape):
         mat_slice = chi_mat[..., idx[0], idx[1], idx[2], idx[3]].flatten()
         try:
-            coeffs = fit_oz_spin(config.lattice.q_grid, mat_slice) if not np.all(mat_slice == 0) else [0.0, 0.0]
+            coeffs = fit_oz_spin(config.lattice.k_grid, mat_slice) if not np.all(mat_slice == 0) else [0.0, 0.0]
         except (ValueError, RuntimeError, opt.OptimizeWarning):
             failed_orbitals.append(idx)
             coeffs = [-1.0, -1.0]
@@ -687,7 +687,7 @@ def calculate_sigma_from_kernel(kernel: FourPoint, giwk: GreensFunction, my_full
             k_slice = kernel[idx_q, ..., idx_w, config.box.niv_core :]
             mat += np.einsum("aijdv,xyzadv->xyzijv", k_slice, g_qk, optimize=path)
 
-    mat *= -0.5 / config.sys.beta / config.lattice.q_grid.nk_tot
+    mat *= -0.5 / config.sys.beta / config.lattice.k_grid.nk_tot
     return SelfEnergy(mat, config.lattice.nk, False, beta=config.sys.beta).compress_q_dimension().to_full_niv_range()
 
 
@@ -736,7 +736,7 @@ def calculate_sigma_from_kernel_cpu(
             np.einsum("xyzadv,aijdv->xyzijv", g_slice, k_slice, out=acc, optimize=True)
             np.add(mat, acc, out=mat)
 
-    mat *= -0.5 / config.sys.beta / config.lattice.q_grid.nk_tot
+    mat *= -0.5 / config.sys.beta / config.lattice.k_grid.nk_tot
     return (
         SelfEnergy(np.ascontiguousarray(mat), config.lattice.nk, False, beta=config.sys.beta)
         .compress_q_dimension()
@@ -787,7 +787,7 @@ def calculate_sigma_from_kernel_gpu(
             k_slice = kernel[iq, ..., iw, :]
             mat_gpu += cp.einsum("xyzadv,aijdv->xyzijv", g_slice, k_slice, optimize=True)
 
-    mat_gpu *= -0.5 / config.sys.beta / config.lattice.q_grid.nk_tot
+    mat_gpu *= -0.5 / config.sys.beta / config.lattice.k_grid.nk_tot
     return (
         SelfEnergy(np.ascontiguousarray(cp.asnumpy(mat_gpu)), config.lattice.nk, False, beta=config.sys.beta)
         .compress_q_dimension()
@@ -869,7 +869,7 @@ def calculate_sigma_from_kernel_fft_cpu(
     rank = comm.Get_rank()
     size = comm.Get_size()
     nkx, nky, nkz = config.lattice.k_grid.nk
-    nk_tot = config.lattice.q_grid.nk_tot
+    nk_tot = config.lattice.k_grid.nk_tot
     nb = config.sys.n_bands
     niv_core = config.box.niv_core
     beta = config.sys.beta
@@ -946,7 +946,7 @@ def calculate_sigma_from_kernel_fft_gpu(
     rank = comm.Get_rank()
     size = comm.Get_size()
     nkx, nky, nkz = config.lattice.k_grid.nk
-    nk_tot = config.lattice.q_grid.nk_tot
+    nk_tot = config.lattice.k_grid.nk_tot
     nb = config.sys.n_bands
     niv_core = config.box.niv_core
     beta = config.sys.beta
@@ -1402,7 +1402,7 @@ def calculate_sigma_proposal(
             config.box.niw_core,
             config.box.niv_full,
             my_irr_q_list,
-            config.lattice.q_grid,
+            config.lattice.k_grid,
             config.sys.beta,
             config.logger,
         )
@@ -1943,14 +1943,14 @@ def calculate_self_energy_q(
 
     # MPI distributor for the irreducible BZ
     mpi_dist_irrk = MpiDistributor.create_distributor(
-        ntasks=config.lattice.q_grid.nk_irr, comm=comm, name="Q", output_path=config.output.output_path
+        ntasks=config.lattice.k_grid.nk_irr, comm=comm, name="Q", output_path=config.output.output_path
     )
-    full_q_list = config.lattice.q_grid.get_q_list()
-    irrk_q_list = config.lattice.q_grid.get_irrq_list()
+    full_q_list = config.lattice.k_grid.get_q_list()
+    irrk_q_list = config.lattice.k_grid.get_irrq_list()
     my_irr_q_list = irrk_q_list[mpi_dist_irrk.my_slice]
 
     mpi_dist_fullbz = MpiDistributor.create_distributor(
-        ntasks=config.lattice.q_grid.nk_tot, comm=comm, name="FBZ", output_path=config.output.output_path
+        ntasks=config.lattice.k_grid.nk_tot, comm=comm, name="FBZ", output_path=config.output.output_path
     )
     my_full_q_list = full_q_list[mpi_dist_fullbz.my_slice]
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -45,7 +45,6 @@ The next section describes the Hamiltonian and the lattice symmetries of the sys
      interaction_type: "one_band_from_dmft" # str
      interaction_input: ""                  # str
      nk: [ 16, 16, 1 ]                      # list[int]
-     # nq: [ 16, 16, 1 ]                    # list[int]
 
 The ``symmetries`` field controls how the irreducible Brillouin zone is built. Entering ``auto`` enables the
 automatic symmetry discovery, which probes a large number of combined momentum and orbital transformations,
@@ -75,9 +74,8 @@ the code read the interaction from the file referenced in ``interaction_input``,
 real-space Hamiltonian file but with four orbital indices instead of two and may also encode non-local
 interactions.
 
-Finally, ``nk`` and ``nq`` set the sizes of the momentum grid for the one-particle quantities and for the
-ladder, respectively. The ``nq`` field may be left unset, in which case ``nk`` is reused for the q-grid. Note that
-the Eliashberg equation can only be solved when the two grids have the same size.
+Finally, ``nk`` sets the size of the momentum grid, which is shared by the one-particle quantities and the
+ladder (the q-grid always equals the k-grid).
 
 Self-consistency
 ----------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,9 +99,7 @@ def create_default_config(config, folder: str):
     config.box.niv_shell = 10
     config.output.do_plotting = False
     config.lattice.nk = (4, 4, 1)
-    config.lattice.nq = config.lattice.nk
     config.lattice.k_grid = bz.KGrid(config.lattice.nk, symmetries=bz.two_dimensional_square_symmetries())
-    config.lattice.q_grid = config.lattice.k_grid
     config.lattice.type = "from_wannierHK"
     config.lattice.interaction_type = "kanamori_from_dmft"
     config.lattice.er_input = f"{folder}/wannier.hk"

--- a/tests/test_autodetect_memory.py
+++ b/tests/test_autodetect_memory.py
@@ -30,7 +30,7 @@ def fake_system(monkeypatch):
     config.memory.save_memory_for_chiq_aux = False
     config.memory.save_memory_for_fq = False
     config.memory.save_memory_for_lanczos = False
-    config.lattice.q_grid = SimpleNamespace(nk_tot=FIXTURE_PARAMS["nk_tot"], nk_irr=FIXTURE_PARAMS["nk_irr"])
+    config.lattice.k_grid = SimpleNamespace(nk_tot=FIXTURE_PARAMS["nk_tot"], nk_irr=FIXTURE_PARAMS["nk_irr"])
     config.logger = MagicMock()
 
     monkeypatch.setattr(dgamore_main.MPI, "Get_processor_name", lambda: "node0", raising=False)

--- a/tests/test_data/end_2_end/dga_config.yaml
+++ b/tests/test_data/end_2_end/dga_config.yaml
@@ -16,7 +16,6 @@ lattice:
   interaction_input: [1, 0, 0, 0]     # Full path to the interaction file or list of interaction parameters [n_bands, U, J, U'] (U' is optional; if left empty, U' is set to U-2J)
   # this parameter will only be used if interaction_type is either 'kanamori' or 'custom'
   nk: [4, 4, 1]     # Number of k-points in x, y and z-direction. Default: [ 16, 16, 1 ]
-  #nq: [ 16, 16, 1 ] # Number of q-points in x, y and z-direction. Default: [ 16, 16, 1 ]. If left empty, nq is set to nk
 
 self_consistency:
   max_iter: 1 # Maximum number of iterations

--- a/tests/test_data/srvo3_end2end/dga_config_cubic.yaml
+++ b/tests/test_data/srvo3_end2end/dga_config_cubic.yaml
@@ -15,7 +15,6 @@ lattice:
   # this parameter will only be used if interaction_type is either 'kanamori' or 'custom'
   orbital_basis: "t2g"
   nk: [ 4,4,4 ] # Number of k-points in x, y and z-direction. Default: [ 16, 16, 1 ]
-  #nq: [ 16, 16, 1 ] # Number of q-points in x, y and z-direction. Default: [ 16, 16, 1 ]. If left empty, nq is set to nk
 
 self_consistency:
   max_iter: 1 # Maximum number of iterations

--- a/tests/test_data/srvo3_end2end/dga_config_inv.yaml
+++ b/tests/test_data/srvo3_end2end/dga_config_inv.yaml
@@ -15,7 +15,6 @@ lattice:
   # this parameter will only be used if interaction_type is either 'kanamori' or 'custom'
   orbital_basis: "t2g"
   nk: [ 4,4,4 ] # Number of k-points in x, y and z-direction. Default: [ 16, 16, 1 ]
-  #nq: [ 16, 16, 1 ] # Number of q-points in x, y and z-direction. Default: [ 16, 16, 1 ]. If left empty, nq is set to nk
 
 self_consistency:
   max_iter: 1 # Maximum number of iterations

--- a/tests/test_eliashberg_end_to_end.py
+++ b/tests/test_eliashberg_end_to_end.py
@@ -83,7 +83,7 @@ def test_eliashberg_equation_without_local_part(setup, save_fq, save_memory):
     config.memory.save_memory_for_lanczos = save_memory
 
     u_loc = config.lattice.hamiltonian.get_local_u()
-    v_nonloc = config.lattice.hamiltonian.get_vq(config.lattice.q_grid)
+    v_nonloc = config.lattice.hamiltonian.get_vq(config.lattice.k_grid)
 
     g_dga = GreensFunction(np.load(f"{folder}/giwk_dga.npy"), nk=config.lattice.nk)
 
@@ -114,7 +114,7 @@ def test_eliashberg_equation_with_local_part(setup, save_fq, save_memory):
     config.memory.save_memory_for_lanczos = save_memory
 
     u_loc = config.lattice.hamiltonian.get_local_u()
-    v_nonloc = config.lattice.hamiltonian.get_vq(config.lattice.q_grid)
+    v_nonloc = config.lattice.hamiltonian.get_vq(config.lattice.k_grid)
 
     g_dga = GreensFunction(np.load(f"{folder}/giwk_dga.npy"), nk=config.lattice.nk)
 
@@ -162,7 +162,7 @@ def test_kernel_matches_thesis_eliashberg_form_on_two_band_vertex(setup):
     config.memory.save_memory_for_lanczos = False
 
     u_loc = config.lattice.hamiltonian.get_local_u()
-    v_nonloc = config.lattice.hamiltonian.get_vq(config.lattice.q_grid)
+    v_nonloc = config.lattice.hamiltonian.get_vq(config.lattice.k_grid)
     g_dga = GreensFunction(np.load(f"{folder}/giwk_dga.npy"), nk=config.lattice.nk)
 
     captured = {}
@@ -182,7 +182,7 @@ def test_kernel_matches_thesis_eliashberg_form_on_two_band_vertex(setup):
         # the solver consumes the passed vertex (in-place BZ map, fft, sign fold, free), so the momentum-space
         # full-BZ vertex is captured from a copy before the solve
         gamma_full = (
-            gamma_r_pp.copy().map_to_full_bz(config.lattice.q_grid, config.lattice.q_grid.nk).decompress_q_dimension()
+            gamma_r_pp.copy().map_to_full_bz(config.lattice.k_grid, config.lattice.k_grid.nk).decompress_q_dimension()
         )
         captured[channel] = {"gamma": gamma_full.mat.copy()}
         gamma_full.free()
@@ -194,7 +194,7 @@ def test_kernel_matches_thesis_eliashberg_form_on_two_band_vertex(setup):
     with patch("dgamore.eliashberg_solver.solve_eliashberg_lanczos", side_effect=capture_solver):
         eliashberg_solver.solve(g_dga, g_dmft, u_loc, v_nonloc, comm_mock)
 
-    nq = config.lattice.q_grid.nk
+    nq = config.lattice.k_grid.nk
     nq_tot, o, beta = int(np.prod(nq)), config.sys.n_bands, config.sys.beta
     niv_pp = min(config.box.niw_core // 2, config.box.niv_core // 2)
     n2 = 2 * niv_pp

--- a/tests/test_eliashberg_solver.py
+++ b/tests/test_eliashberg_solver.py
@@ -126,7 +126,7 @@ def test_transform_vertex_q_frequencies_w0_matches_untrimmed_reference():
 
     rng = np.random.default_rng(33)
     o, nqi, niw, niv, niv_pp = 2, 2, 9, 4, 2
-    config.lattice.q_grid = bz.KGrid((nqi, 1, 1), symmetries=[])
+    config.lattice.k_grid = bz.KGrid((nqi, 1, 1), symmetries=[])
     shape = (nqi, o, o, o, o, niw + 1, 2 * niv, 2 * niv)
     mat = rng.standard_normal(shape) + 1j * rng.standard_normal(shape)
     vertex = FourPoint(mat, SpinChannel.DENS, (nqi, 1, 1), 1, 2, False, True, True)
@@ -424,9 +424,7 @@ def test_degenerate_decoupled_bands_reproduce_single_band_kernel(channel, o):
     nq, niv_pp, beta = (2, 2, 1), 2, 10.0
     nq_tot, n2 = int(np.prod(nq)), 2 * niv_pp
     config.lattice.nk = nq
-    config.lattice.nq = nq
-    config.lattice.q_grid = bz.KGrid(nq, symmetries=[])
-    config.lattice.k_grid = config.lattice.q_grid
+    config.lattice.k_grid = bz.KGrid(nq, symmetries=[])
     config.sys.beta = beta
     config.eliashberg.n_eig = 2
     config.eliashberg.epsilon = 1e-10

--- a/tests/test_lambda_ops.py
+++ b/tests/test_lambda_ops.py
@@ -47,10 +47,13 @@ def load_local_four_point(lc_type: str, filename: str, channel: SpinChannel) -> 
 
 
 def test_lambda_correction_spch():
-    """spch-type single lambda correction reproduces reference chi and lambdas for dens and magn channels."""
-    config.lattice.q_grid = bz.KGrid(nk=(4, 4, 1), symmetries=bz.two_dimensional_square_symmetries())
+    """spch-type single lambda correction reproduces reference chi and lambdas for dens and magn channels; the dens
+    channel stalls at the divergence bound and warns, so the logger must be mocked for a standalone run."""
+    from unittest.mock import MagicMock
+
     config.lattice.k_grid = bz.KGrid(nk=(4, 4, 1), symmetries=bz.two_dimensional_square_symmetries())
     config.sys.beta = 12.5
+    config.logger = MagicMock()
 
     def perform_lc(channel: SpinChannel):
         chi_r_before_lambda = load_four_point("spch", f"chi_phys_q_{channel.value}_before_lambda", channel)
@@ -73,7 +76,7 @@ def test_lambda_correction_spch():
 
 def test_lambda_correction_sp():
     """sp-type single lambda correction (magn only) reproduces reference chi and lambda."""
-    config.lattice.q_grid = bz.KGrid(nk=(4, 4, 1), symmetries=bz.two_dimensional_square_symmetries())
+    config.lattice.k_grid = bz.KGrid(nk=(4, 4, 1), symmetries=bz.two_dimensional_square_symmetries())
     config.sys.beta = 12.5
 
     chi_dens_q_before_lambda = load_four_point(
@@ -88,7 +91,7 @@ def test_lambda_correction_sp():
     chi_loc_sum = (
         chi_dens_loc_sum
         + chi_magn_loc_sum
-        - 1.0 / 16 * (config.lattice.q_grid.irrk_count[:, None, None, None, None, None] * chi_phys_q_dens.mat).sum()
+        - 1.0 / 16 * (config.lattice.k_grid.irrk_count[:, None, None, None, None, None] * chi_phys_q_dens.mat).sum()
     )
 
     chi_magn_q_before_lambda = load_four_point("sp", f"chi_phys_q_magn_before_lambda", SpinChannel.MAGN)
@@ -106,7 +109,7 @@ def test_lambda_correction_sp():
 @pytest.mark.parametrize("lc_type", ["sp", "spch"])
 def test_lambda_correction_in_sde_sp(lc_type):
     """LambdaCorrection.perform reproduces reference chi for both sp and spch types."""
-    config.lattice.q_grid = bz.KGrid(nk=(4, 4, 1), symmetries=bz.two_dimensional_square_symmetries())
+    config.lattice.k_grid = bz.KGrid(nk=(4, 4, 1), symmetries=bz.two_dimensional_square_symmetries())
     config.sys.beta = 12.5
     config.lambda_correction.type = lc_type
     config.output.output_path = f"{os.path.dirname(os.path.abspath(__file__))}/test_data/lambda_correction/{lc_type}"
@@ -134,11 +137,11 @@ def test_find_lambda_warns_on_non_convergence():
     """find_lambda warns and returns a finite value when the target is unreachable within maxiter."""
     from unittest.mock import MagicMock
 
-    config.lattice.q_grid = bz.KGrid(nk=(4, 4, 1), symmetries=bz.two_dimensional_square_symmetries())
+    config.lattice.k_grid = bz.KGrid(nk=(4, 4, 1), symmetries=bz.two_dimensional_square_symmetries())
     config.sys.beta = 12.5
     config.logger = MagicMock()
 
-    n_irrk = config.lattice.q_grid.irrk_count.shape[0]
+    n_irrk = config.lattice.k_grid.irrk_count.shape[0]
     chi = np.full((n_irrk, 5), 0.5, dtype=np.complex64)  # [irrk, w], finite -> lambda_start finite
     result = LambdaCorrection.find_lambda(chi, 1e6 + 0j, maxiter=1)  # unreachable target in one iteration
 
@@ -247,7 +250,6 @@ def test_find_lambda_matrix_falls_back_to_lstsq_on_singular_hessian():
 def test_multiorbital_perform_single_matches_single_band_for_magn():
     """For the cleanly-converging magnetic channel, the No=1 matrix correction coincides with the scalar
     LambdaCorrection (same lambda and corrected chi on the spch reference data)."""
-    config.lattice.q_grid = bz.KGrid(nk=(4, 4, 1), symmetries=bz.two_dimensional_square_symmetries())
     config.lattice.k_grid = bz.KGrid(nk=(4, 4, 1), symmetries=bz.two_dimensional_square_symmetries())
     config.sys.beta = 12.5
     config.sys.n_bands = 1
@@ -267,7 +269,6 @@ def test_multiorbital_perform_single_matches_single_band_for_magn():
 def test_multiorbital_perform_single_satisfies_sum_rule(channel):
     """The corrected susceptibility's full-BZ frequency sum matches the local target for BOTH channels - including
     density, where the scalar single-band solver stalls at the divergence bound instead of the true root."""
-    config.lattice.q_grid = bz.KGrid(nk=(4, 4, 1), symmetries=bz.two_dimensional_square_symmetries())
     config.lattice.k_grid = bz.KGrid(nk=(4, 4, 1), symmetries=bz.two_dimensional_square_symmetries())
     config.sys.beta = 12.5
     config.sys.n_bands = 1
@@ -278,7 +279,7 @@ def test_multiorbital_perform_single_satisfies_sum_rule(channel):
 
     corrected, _ = MultiOrbitalLambdaCorrection.perform_single(chi_before.copy(), s_r)
 
-    q_grid = config.lattice.q_grid
+    q_grid = config.lattice.k_grid
     lhs = corrected.to_full_niw_range().map_to_full_bz(q_grid).mat.sum() / (config.sys.beta * q_grid.nk_tot)
     assert np.allclose(lhs, s_r[0, 0], atol=1e-6)
 
@@ -286,10 +287,9 @@ def test_multiorbital_perform_single_satisfies_sum_rule(channel):
 def _multiorbital_chi_fourpoint(n_bands: int, nq_grid: tuple, nw_half: int, seed: int) -> FourPoint:
     """Physical two-index-per-leg chi^q FourPoint on the IBZ (no fermionic frequencies): its compound inverse is a
     real-symmetric SPD block with omega^2 growth, so the sum-rule root is unique."""
-    config.lattice.q_grid = bz.KGrid(nk=nq_grid, symmetries=bz.two_dimensional_square_symmetries())
-    config.lattice.k_grid = config.lattice.q_grid
+    config.lattice.k_grid = bz.KGrid(nk=nq_grid, symmetries=bz.two_dimensional_square_symmetries())
     rng = np.random.default_rng(seed)
-    n_irr = config.lattice.q_grid.irrk_count.shape[0]
+    n_irr = config.lattice.k_grid.irrk_count.shape[0]
     no2, nw = n_bands**2, 2 * nw_half + 1
     mat = np.empty((n_irr, n_bands, n_bands, n_bands, n_bands, nw), dtype=np.complex128)
     for q in range(n_irr):
@@ -309,7 +309,7 @@ def test_multiorbital_perform_single_recovers_matrix_mass_and_sum_rule():
     config.sys.beta = 8.0
     config.sys.n_bands = 2
     chi = _multiorbital_chi_fourpoint(2, (4, 4, 1), 3, seed=7)
-    q_grid = config.lattice.q_grid
+    q_grid = config.lattice.k_grid
     no2 = 4
     a = np.random.default_rng(9).standard_normal((no2, no2))
     lambda_star = 0.2 * 0.5 * (a + a.T)
@@ -331,7 +331,6 @@ def test_multiorbital_perform_loads_target_writes_lambda_and_corrects(tmp_path):
     import shutil
     from unittest.mock import MagicMock
 
-    config.lattice.q_grid = bz.KGrid(nk=(4, 4, 1), symmetries=bz.two_dimensional_square_symmetries())
     config.lattice.k_grid = bz.KGrid(nk=(4, 4, 1), symmetries=bz.two_dimensional_square_symmetries())
     config.sys.beta = 12.5
     config.sys.n_bands = 1
@@ -351,10 +350,9 @@ def test_multiorbital_perform_loads_target_writes_lambda_and_corrects(tmp_path):
 
 def test_density_diagonal_sum_reduces_to_frequency_sum_for_q_constant_chi():
     """C_{r;a} = (1/(beta N_q)) sum_qw chi_aaaa reduces to (1/beta) sum_w chi_aaaa when chi is momentum-constant."""
-    config.lattice.q_grid = bz.KGrid(nk=(4, 4, 1), symmetries=bz.two_dimensional_square_symmetries())
-    config.lattice.k_grid = config.lattice.q_grid
+    config.lattice.k_grid = bz.KGrid(nk=(4, 4, 1), symmetries=bz.two_dimensional_square_symmetries())
     config.sys.beta = 5.0
-    n_irr, nw, n_bands = config.lattice.q_grid.irrk_count.shape[0], 5, 2
+    n_irr, nw, n_bands = config.lattice.k_grid.irrk_count.shape[0], 5, 2
     single_q = np.random.default_rng(3).standard_normal((n_bands, n_bands, n_bands, n_bands, nw)) + 0.5
     mat = np.broadcast_to(single_q, (n_irr, *single_q.shape)).astype(np.complex128).copy()
     chi = FourPoint(
@@ -476,7 +474,6 @@ def test_multiorbital_perform_quiet_writes_nothing_and_skips_pauli(tmp_path):
     import shutil
     from unittest.mock import MagicMock
 
-    config.lattice.q_grid = bz.KGrid(nk=(4, 4, 1), symmetries=bz.two_dimensional_square_symmetries())
     config.lattice.k_grid = bz.KGrid(nk=(4, 4, 1), symmetries=bz.two_dimensional_square_symmetries())
     config.sys.beta = 12.5
     config.sys.n_bands = 1
@@ -535,7 +532,7 @@ def test_expand_compound_slice_is_exact_gather_without_auto_data():
     """Without auto-symmetry data the FBZ expansion is the plain irrk_inv gather, bit-identical per bosonic
     frequency to what map_to_full_bz produces."""
     grid = bz.KGrid(nk=(4, 4, 1), symmetries=bz.two_dimensional_square_symmetries())
-    config.lattice.q_grid = grid
+    config.lattice.k_grid = grid
     chi = _chi_on_grid(grid, 2, 2, seed=5)
     expected = chi.copy().map_to_full_bz(grid).to_compound_indices().mat
     irr = chi.copy().to_compound_indices().mat
@@ -568,7 +565,7 @@ def test_find_lambda_matrix_ibz_resident_matches_full_bz_reference(auto):
     transform-noise level on an auto grid with genuine orbital rotations."""
     beta, n_bands = 5.0, 2
     grid = _synthetic_auto_grid() if auto else bz.KGrid(nk=(4, 4, 1), symmetries=bz.two_dimensional_square_symmetries())
-    config.lattice.q_grid = grid
+    config.lattice.k_grid = grid
     chi = _chi_on_grid(grid, n_bands, 2, seed=7)
     no2 = n_bands**2
     a = np.random.default_rng(8).standard_normal((no2, no2))

--- a/tests/test_local_sde_end_to_end.py
+++ b/tests/test_local_sde_end_to_end.py
@@ -112,7 +112,7 @@ def test_extracts_dmft_quantities_correctly(setup, niw_core, niv_core, niv_shell
     mask[indices, indices, indices, indices] = False
     assert np.all(u_loc.mat[mask] == 0)
 
-    vq = config.lattice.hamiltonian.get_vq(config.lattice.q_grid)
+    vq = config.lattice.hamiltonian.get_vq(config.lattice.k_grid)
     assert vq.mat.shape == (4, 4, 1, 2, 2, 2, 2)
     assert np.allclose(vq.mat, np.zeros_like(vq.mat))
 

--- a/tests/test_max_ent.py
+++ b/tests/test_max_ent.py
@@ -145,9 +145,7 @@ def _build_giwk_mat(nk, n_bands, niv, seed=1):
 
 def _setup_maxent_config(tmp_path, nk, n_bands, niv_core=3, w_count=7, seed=0):
     config.lattice.nk = nk
-    config.lattice.nq = nk
     config.lattice.k_grid = bz.KGrid(nk, symmetries=bz.two_dimensional_square_symmetries())
-    config.lattice.q_grid = config.lattice.k_grid
     config.box.niv_core = niv_core
     config.sys.beta = 10.0
     config.sys.n_bands = n_bands

--- a/tests/test_mpi_utils.py
+++ b/tests/test_mpi_utils.py
@@ -164,7 +164,7 @@ def test_map_irrbz_fullbz():
     """map_irrbz_fullbz expands the distributed IBZ object to the full BZ."""
 
     def fn(comm, rank):
-        config.lattice.q_grid = _q_grid()
+        config.lattice.k_grid = _q_grid()
         d_irr = MpiDistributor(ntasks=N_IRR, comm=comm)
         d_full = MpiDistributor(ntasks=N_FULL, comm=comm)
         obj = FourPoint(G_IRR[d_irr.my_slice].copy(), nq=Q_NK, has_compressed_q_dimension=True)
@@ -180,7 +180,7 @@ def test_exchange_and_map_matches_reference():
     """exchange_and_map_irrbz_fullbz reproduces the reference full-BZ expansion."""
 
     def fn(comm, rank):
-        config.lattice.q_grid = _q_grid()
+        config.lattice.k_grid = _q_grid()
         d_irr = MpiDistributor(ntasks=N_IRR, comm=comm)
         d_full = MpiDistributor(ntasks=N_FULL, comm=comm)
         obj = FourPoint(
@@ -196,7 +196,7 @@ def test_exchange_and_map_matches_reference():
 
 def test_exchange_and_map_single_rank():
     """exchange_and_map_irrbz_fullbz works on a single rank and propagates metadata."""
-    config.lattice.q_grid = _q_grid()
+    config.lattice.k_grid = _q_grid()
     comm = MPI.Comm(1)
     d_irr = MpiDistributor(ntasks=N_IRR, comm=comm)
     d_full = MpiDistributor(ntasks=N_FULL, comm=comm)
@@ -241,7 +241,7 @@ def test_exchange_and_map_auto_orbital_transform(monkeypatch):
         return g
 
     def fn(comm, rank):
-        config.lattice.q_grid = _auto_grid()
+        config.lattice.k_grid = _auto_grid()
         d_irr = MpiDistributor(ntasks=N_IRR, comm=comm)
         d_full = MpiDistributor(ntasks=N_FULL, comm=comm)
         obj = FourPoint(G_IRR[d_irr.my_slice].copy(), nq=Q_NK, has_compressed_q_dimension=True)
@@ -285,7 +285,7 @@ def test_exchange_and_map_data_exchange_is_chunked(monkeypatch):
         monkeypatch.setattr(mu, "MAX_MPI_BYTES", limit)
 
         def fn(comm, rank):
-            config.lattice.q_grid = KGrid(nk, syms)
+            config.lattice.k_grid = KGrid(nk, syms)
             d_irr = MpiDistributor(ntasks=n_irr, comm=comm)
             d_full = MpiDistributor(ntasks=n_full, comm=comm)
             obj = FourPoint(g_irr[d_irr.my_slice].copy(), nq=nk, has_compressed_q_dimension=True)
@@ -443,7 +443,7 @@ def test_gather_full_ibz_for_vslice():
     G = (np.arange(n_irrq * norb * n_v * n_vp).reshape(n_irrq, norb, n_v, n_vp) + 1j).astype(np.complex128)
 
     def fn(comm, rank):
-        config.lattice.q_grid = q_grid
+        config.lattice.k_grid = q_grid
         d_irrq = MpiDistributor(ntasks=n_irrq, comm=comm)
         d_v = MpiDistributor(ntasks=n_v, comm=comm)
         gamma = FourPoint(G[d_irrq.my_slice].copy(), nq=(2, 2, 1), has_compressed_q_dimension=True)
@@ -471,7 +471,7 @@ def test_gather_full_ibz_for_vslice_tags_stay_below_mpi_tag_ub_minimum():
     seen_tags = []
 
     def fn(comm, rank):
-        config.lattice.q_grid = q_grid
+        config.lattice.k_grid = q_grid
         orig_isend, orig_irecv = comm.Isend, comm.Irecv
 
         def isend(buf, dest, tag=0):
@@ -505,7 +505,7 @@ def test_gather_full_ibz_for_vslice_empty_rank_returns_none():
     G = (np.arange(n_irrq * norb * n_v * n_vp).reshape(n_irrq, norb, n_v, n_vp) + 1j).astype(np.complex128)
 
     def fn(comm, rank):
-        config.lattice.q_grid = q_grid
+        config.lattice.k_grid = q_grid
         d_irrq = MpiDistributor(ntasks=n_irrq, comm=comm)
         d_v = MpiDistributor(ntasks=n_v, comm=comm)
         gamma = FourPoint(G[d_irrq.my_slice].copy(), nq=(3, 1, 1), has_compressed_q_dimension=True)

--- a/tests/test_nonlocal_sde.py
+++ b/tests/test_nonlocal_sde.py
@@ -71,7 +71,6 @@ def test_nonlocal_hartree_fock_matches_local_reference():
     nq_tot = int(np.prod(nk))
 
     config.lattice.nk = nk
-    config.lattice.nq = nk
     config.sys.n_bands = nb
 
     occ = np.load(f"{LOCAL_SDE_DATA}/occ.npy", allow_pickle=False)
@@ -386,7 +385,6 @@ def test_unused_qloop_sigma_variants_agree():
     nk, o, niw, niv = (4, 4, 1), 2, 3, 4
     config.lattice.nk = nk
     config.lattice.k_grid = bz.KGrid(nk, symmetries=[])
-    config.lattice.q_grid = config.lattice.k_grid
     config.box.niw_core = niw
     config.box.niv_core = niv
     config.sys.n_bands = o
@@ -400,7 +398,7 @@ def test_unused_qloop_sigma_variants_agree():
     g_mat = (rng.standard_normal(g_shape) + 1j * rng.standard_normal(g_shape)).astype(np.complex64)
     kernel_mat = (rng.standard_normal(k_shape) + 1j * rng.standard_normal(k_shape)).astype(np.complex64)
     giwk = GreensFunction(g_mat, calc_filling=False, nk=nk, beta=config.sys.beta)
-    q_list = config.lattice.q_grid.get_q_list()
+    q_list = config.lattice.k_grid.get_q_list()
 
     def make_kernel():
         return FourPoint(
@@ -530,7 +528,6 @@ def test_sde_fft_rspace_greens_function_node_sharing_matches_private_build():
     nk, o, niw, niv = (4, 4, 1), 2, 3, 4
     config.lattice.nk = nk
     config.lattice.k_grid = bz.KGrid(nk, symmetries=[])
-    config.lattice.q_grid = config.lattice.k_grid
     config.box.niw_core = niw
     config.box.niv_core = niv
     config.sys.n_bands = o
@@ -1323,7 +1320,6 @@ def _setup_self_energy_loop(monkeypatch, tmp_path, proposal_step, max_iter=10, e
     from types import SimpleNamespace
 
     config.lattice.k_grid = bz.KGrid((1, 1, 1), symmetries=[])
-    config.lattice.q_grid = config.lattice.k_grid
     config.lattice.hamiltonian = SimpleNamespace(get_ek=lambda: np.zeros((1, 1, 1, 1, 1)))
     config.box.niw_core, config.box.niv_core, config.box.niv_full, config.box.niv_dmft = 1, 2, 2, 8
     config.sys.beta, config.sys.mu, config.sys.n = 10.0, 0.5, 1.0

--- a/tests/test_nonlocal_sde_end_to_end.py
+++ b/tests/test_nonlocal_sde_end_to_end.py
@@ -41,9 +41,7 @@ def setup_srvo3_cubic():
         c.box.niv_shell = 0
         c.output.do_plotting = False
         c.lattice.nk = (12, 12, 12)
-        c.lattice.nq = config.lattice.nk
         c.lattice.k_grid = bz.KGrid(c.lattice.nk, [KnownSymmetries.AUTO])
-        c.lattice.q_grid = c.lattice.k_grid
         c.lattice.symmetries = [KnownSymmetries.AUTO]
         c.lattice.type = "from_wannier90"
         c.lattice.interaction_type = "kanamori_from_dmft"
@@ -172,7 +170,7 @@ def test_calculates_nonlocal_sde_correctly(setup, niw_core, niv_core, niv_shell,
     config.output.output_path = folder
 
     u_loc = config.lattice.hamiltonian.get_local_u()
-    v_nonloc = config.lattice.hamiltonian.get_vq(config.lattice.q_grid)
+    v_nonloc = config.lattice.hamiltonian.get_vq(config.lattice.k_grid)
 
     *_, s_loc = local_sde.perform_local_schwinger_dyson(g_dmft, g2_dens, g2_magn, u_loc)
 
@@ -209,7 +207,6 @@ def test_calculates_srvo3_correctly(setup_srvo3_cubic, save_memory):
     config.sys.occ_dmft = config.sys.occ_dmft_per_ineq[0]
 
     config.lattice.k_grid.specify_auto_symmetries(ek, atol=1e-12)
-    config.lattice.q_grid.specify_auto_symmetries(ek, atol=1e-12)
 
     s_dmft_ref = np.load(f"{folder_cubic}/sigma_dmft.npy")
     assert np.allclose(s_dmft_ref, s_dmft_ref)
@@ -217,7 +214,7 @@ def test_calculates_srvo3_correctly(setup_srvo3_cubic, save_memory):
     assert np.allclose(g_dmft_ref, g_dmft_ref)
 
     u_loc = config.lattice.hamiltonian.get_local_u()
-    v_nonloc = config.lattice.hamiltonian.get_vq(config.lattice.q_grid)
+    v_nonloc = config.lattice.hamiltonian.get_vq(config.lattice.k_grid)
 
     *_, s_loc = local_sde.perform_local_schwinger_dyson(g_dmft, g2_dens, g2_magn, u_loc)
 


### PR DESCRIPTION
Removed the nq option from the setting, since for the code to work properly with the FFT and Eliashberg, nk = nq is needed. Hence, we unified both grids into a single grid quantity and just let the user specify the k-grid.