### PR TITLE
Symmetrization of gaps now also for 3D systems and triple-degenerate eigenvalues

### DIFF
--- a/dgamore/brillouin_zone.py
+++ b/dgamore/brillouin_zone.py
@@ -390,7 +390,7 @@ class KGrid:
         """
         Builds the k-axes and the irreducible-BZ maps from the grid size and symmetries.
 
-        :param nk: Number of k-points per spatial direction, as a tuple ``(nx, ny, nz)``.
+        :param nk: Number of k-points per spatial direction ``(nx, ny, nz)``.
         :param symmetries: A list of :class:`KnownSymmetries` defining the irreducible BZ, or
             ``[KnownSymmetries.AUTO]`` to defer symmetry discovery to :meth:`specify_auto_symmetries`.
         """
@@ -685,7 +685,7 @@ class KPath:
         r"""
         Builds the k-axes and the discretized path (and its k-points) from the path string.
 
-        :param nk: Number of k-points per spatial direction, as a tuple ``(nx, ny, nz)``.
+        :param nk: Number of k-points per spatial direction ``(nx, ny, nz)``.
         :param path: The desired path through the BZ as a delimiter-separated string of corner-point labels.
         :param kx: Optional explicit kx-axis array; a :math:`[0, 2\pi)` grid is built if None.
         :param ky: Optional explicit ky-axis array; a :math:`[0, 2\pi)` grid is built if None.
@@ -908,7 +908,7 @@ def kpath_segment(k_start, k_end, nk):
 
     :param k_start: Fractional coordinates of the segment start point.
     :param k_end: Fractional coordinates of the segment end point.
-    :param nk: Number of k-points per spatial direction.
+    :param nk: Number of k-points per spatial direction ``(nx, ny, nz)``.
     :return: A tuple ``(k_segment, nkp)`` of the integer index array along the segment and the number of points.
     """
     nkp = int(np.round(np.linalg.norm(k_start * nk - k_end * nk, ord=np.inf)))

--- a/dgamore/eliashberg_solver.py
+++ b/dgamore/eliashberg_solver.py
@@ -498,7 +498,7 @@ def create_local_gamma_ud_pp_w0(
     :param gchi0_pp_w0: The local bare pp bubble :math:`\chi^{pp;\nu\nu'}_{0;1234}` (diagonal in :math:`\nu\nu'`),
         built from the DMFT Green's function via
         :meth:`~dgamore.bubble_gen.BubbleGenerator.create_generalized_chi0_pp_w0`.
-    :param beta: Inverse temperature :math:`\beta`, see ``beta`` of :class:`~dgamore.config.SystemConfig`.
+    :param beta: Inverse temperature :math:`\beta`.
     :return: The vertex :math:`\Gamma^{pp;\nu\nu'}_{\uparrow\downarrow;1234}` as a :class:`LocalFourPoint` in pp
         notation.
     """
@@ -892,7 +892,7 @@ def _v2_solver_thread_budget(comm: MPI.Comm, active_ranks: list) -> int:
     launcher binding leaves masks wider than one core (e.g. socket binding) and some of the node's ranks hold
     empty frequency slices. This is a collective call - every rank of ``comm`` must enter it, active or not.
 
-    :param comm: The full MPI communicator.
+    :param comm: The MPI communicator.
     :param active_ranks: The ranks holding non-empty frequency slices (see :func:`solve_eliashberg_lanczos_v2`).
     :return: The thread budget of this rank as an int (1 for inactive ranks and where no affinity API exists).
     """
@@ -928,15 +928,63 @@ def _chi0_to_matmul_layout(chi0_mat: np.ndarray) -> np.ndarray:
     return np.moveaxis(chi0_mat.reshape(nqx, nqy, nqz, nb * nb, nb * nb, v), -1, 3)
 
 
+def _orient_cluster_by_mirrors(block: np.ndarray, gap_shape: tuple, tol: float = 1e-6) -> np.ndarray | None:
+    r"""
+    Rotates an orthonormal degenerate cluster onto the common eigenbasis of the single-axis coordinate mirrors
+    :math:`k_i \to -k_i` and orders the partners lexicographically by the tuple of axes each one is odd under. The
+    mirrors mutually commute, so one generic real combination of their projections into the cluster (weights
+    :math:`1, \sqrt{2}, \sqrt{3}`, giving a distinct eigenvalue per sign pattern) shares their eigenvectors; each
+    partner's mirror eigenvalues are read off as Rayleigh quotients. Single-axis :math:`p`-like partners sort
+    ``x, y, z`` and two-axis :math:`d`-like partners (:math:`d_{xy}`, :math:`d_{xz}`, :math:`d_{yz}`) sort
+    ``xy, xz, yz``.
+
+    :param block: Orthonormal cluster, one flattened gap function per column.
+    :param gap_shape: Full gap shape ``[kx, ky, kz, o1, o2, 2*niv_pp]``.
+    :param tol: Tolerance on the deviation of a mirror Rayleigh quotient from :math:`\pm 1`.
+    :return: The reordered cluster, or ``None`` when no momentum axis is resolved or a partner is not a clean
+        :math:`\pm 1` mirror eigenstate.
+    """
+
+    def reflect_axis(column: np.ndarray, axis: int) -> np.ndarray:
+        idx = (gap_shape[axis] - np.arange(gap_shape[axis])) % gap_shape[axis]
+        take = [slice(None)] * len(gap_shape)
+        take[axis] = idx
+        return column.reshape(gap_shape)[tuple(take)].ravel()
+
+    axes = [axis for axis in (0, 1, 2) if gap_shape[axis] > 1]
+    if not axes:
+        return None
+
+    projected = []
+    for axis in axes:
+        mirrored = np.stack([reflect_axis(block[:, i], axis) for i in range(block.shape[1])], axis=1)
+        m = block.conj().T @ mirrored
+        projected.append(0.5 * (m + m.conj().T))
+
+    weights = np.sqrt(np.arange(1, len(projected) + 1, dtype=float))  # 1, sqrt(2), sqrt(3): generic, deterministic
+    _, vecs = np.linalg.eigh(sum(w * m for w, m in zip(weights, projected)))
+
+    keys = []
+    for col in range(vecs.shape[1]):
+        c = vecs[:, col]
+        signature = np.array([(c.conj() @ m @ c).real for m in projected])
+        if np.any(np.abs(np.abs(signature) - 1.0) > tol):  # not a clean +/-1 mirror eigenstate
+            return None
+        keys.append(tuple(int(a) for a in np.flatnonzero(signature < 0.0)))
+
+    block = block @ vecs
+    return block[:, sorted(range(len(keys)), key=lambda col: keys[col])]
+
+
 def symmetrize_degenerate_gaps(
     lambdas: np.ndarray, gaps: np.ndarray, gap_shape: tuple, tol: float = 1e-4
 ) -> np.ndarray:
     r"""
     Orthonormalizes the eigenvectors returned by the Lanczos solver within clusters of (near-)degenerate
-    eigenvalues and rotates every two-dimensional cluster to the mirror-adapted basis. The pairing kernel is only
-    symmetrizable, not Hermitian in the plain inner product, so ARPACK may return oblique (mutually
-    non-orthogonal) combinations inside a degenerate doublet: the doublet subspace is symmetry-covariant, but the
-    two returned vectors then do not form 90-degree-rotated partners.
+    eigenvalues and rotates every cluster to a mirror-adapted basis. The pairing kernel is only symmetrizable, not
+    Hermitian in the plain inner product, so ARPACK may return oblique (mutually non-orthogonal) combinations
+    inside a degenerate cluster: the cluster subspace is symmetry-covariant, but the returned vectors then do not
+    form the symmetry-adapted partners.
 
     Per cluster the following steps are applied: (i) Loewdin orthonormalization, i.e. :math:`S^{-1/2}` applied to
     the cluster overlap matrix :math:`S`, which yields the orthonormal basis closest to the input vectors; (ii)
@@ -945,14 +993,18 @@ def symmetrize_degenerate_gaps(
     .. math:: M_y: \Delta_{12}(k_x, k_y, k_z, \nu) \to \Delta_{12}(k_x, -k_y, k_z, \nu)
 
     is diagonalized within the cluster, ordering the even (:math:`+1`, :math:`p_x`-like) partner first and the
-    odd (:math:`-1`, :math:`p_y`-like) partner second; (iii) the global phase of every vector is fixed such that
-    its largest-magnitude element is real and positive. Eigenvalues are not modified; vectors of non-degenerate
+    odd (:math:`-1`, :math:`p_y`-like) partner second; every cluster of three or more members is handled by
+    :func:`_orient_cluster_by_mirrors`, which diagonalizes the single-axis coordinate mirrors of the resolved axes
+    simultaneously and orders the partners by the axes each one is odd under (:math:`p`-like as ``x, y, z``,
+    two-axis :math:`d`-like as ``xy, xz, yz``), provided every partner is a clean :math:`\pm 1` eigenstate
+    (otherwise the Loewdin basis is kept); (iii) the global phase of every vector is fixed such that its
+    largest-magnitude element is real and positive. Eigenvalues are not modified; vectors of non-degenerate
     eigenvalues are only phase-fixed. Enabled via ``symmetrize_degenerate_gaps`` of
     :class:`~dgamore.config.EliashbergConfig`.
 
     :param lambdas: Eigenvalues sorted in descending order.
     :param gaps: Eigenvector matrix ``[n, n_eig]`` with one flattened gap function per column.
-    :param gap_shape: Full gap shape ``[kx, ky, kz, o1, o2, 2*niv_pp]``, used to locate the :math:`k_y` axis.
+    :param gap_shape: Full gap shape ``[kx, ky, kz, o1, o2, 2*niv_pp]``, used to locate the momentum axes.
     :param tol: Relative tolerance for clustering neighboring eigenvalues as degenerate.
     :return: The symmetrized eigenvector matrix ``[n, n_eig]``.
     """
@@ -988,6 +1040,10 @@ def symmetrize_degenerate_gaps(
             _, mirror_vecs = np.linalg.eigh(mirror_block)
             # order the even (+1, p_x-like) partner first and the odd (-1, p_y-like) partner second
             block = block @ mirror_vecs[:, ::-1]
+        elif len(cluster) >= 3:
+            oriented = _orient_cluster_by_mirrors(block, gap_shape)
+            if oriented is not None:
+                block = oriented
 
         for col in range(block.shape[1]):
             mags = np.abs(block[:, col])
@@ -1188,7 +1244,7 @@ def _solve_pairing_sectors(
         if executor is not None:
             executor.shutdown()
 
-    logger.info(f"Finished solving the Eliashberg equation for the {channel.value}let channel.", allowed_ranks=ranks)
+    logger.info(f"Finished solving the Eliashberg equation for the {channel.value}let channel.", allowed_ranks=ranks[0])
     return results
 
 
@@ -1219,11 +1275,11 @@ def solve_eliashberg_lanczos(
 
     logger.info(
         f"Starting to solve the Eliashberg equation for the {gamma_r_pp.channel.value}let channel.",
-        allowed_ranks=ranks,
+        allowed_ranks=ranks[0],
     )
 
     gamma_r_pp = gamma_r_pp.map_to_full_bz(config.lattice.k_grid, config.lattice.k_grid.nk).decompress_q_dimension()
-    logger.log_memory_usage(f"Gamma_pp_{gamma_r_pp.channel.value}", gamma_r_pp, 1, allowed_ranks=ranks)
+    logger.log_memory_usage(f"Gamma_pp_{gamma_r_pp.channel.value}", gamma_r_pp, 1, allowed_ranks=ranks[0])
 
     gamma_r_pp = gamma_r_pp.fft(False)
 
@@ -1402,7 +1458,7 @@ def solve_eliashberg_lanczos_v2(
         return np.moveaxis(gap_new, 0, -1).flatten()  # (nq_tot, orb, orb, v_total)
 
     return _solve_pairing_sectors(
-        mv, gap_shape, sign, gamma_r_pp.channel, gamma_r_pp.nq, executor, root, gap0.flatten()
+        mv, gap_shape, sign, gamma_r_pp.channel, gamma_r_pp.nq, executor, (root,), gap0.flatten()
     )
 
 
@@ -1466,7 +1522,7 @@ def _solve_sectors_in_memory(
     only rank still holding ``giwk_dga``) and shipped to the other solving ranks. The results are broadcast from each
     sector's owning rank so every rank returns the full dict.
 
-    :param mpi_dist_irrk: The irreducible-BZ q-distributor.
+    :param mpi_dist_irrk: MPI distributor over the irreducible BZ q-points (see :class:`MpiDistributor`).
     :param gamma_sing_pp: The singlet pairing vertex (irr-BZ q-distributed on entry; consumed).
     :param gamma_trip_pp: The triplet pairing vertex (irr-BZ q-distributed on entry; consumed).
     :param giwk_dga: The DGA Green's function (held only on ``bubble_rank``; used to build the bubble).

--- a/dgamore/four_point.py
+++ b/dgamore/four_point.py
@@ -47,13 +47,13 @@ class FourPoint(IAmNonLocal, LocalFourPoint):
 
         :param mat: Underlying array with one momentum axis (compressed or not), four orbital axes, then frequency axes.
         :param channel: Spin channel of the object (see :class:`SpinChannel`).
-        :param nq: Number of momenta per spatial direction.
-        :param num_wn_dimensions: Number of bosonic frequency axes (0–1).
-        :param num_vn_dimensions: Number of fermionic frequency axes (0–2).
+        :param nq: Number of momenta per spatial direction ``(nx, ny, nz)``.
+        :param num_wn_dimensions: Number of bosonic frequency axes (0 or 1).
+        :param num_vn_dimensions: Number of fermionic frequency axes (0, 1 or 2).
         :param full_niw_range: Whether the object spans the full (signed) bosonic range or only :math:`\omega \geq 0`.
         :param full_niv_range: Whether the object spans the full (signed) fermionic range or only :math:`\nu \geq 0`.
         :param has_compressed_q_dimension: Whether the momentum is stored as a single compressed axis ``[q, ...]``
-            (True) or as ``[qx, qy, qz, ...]`` (False).
+            (True) or as three separate axes ``[qx, qy, qz, ...]`` (False).
         :param frequency_notation: Frequency convention (see :class:`FrequencyNotation`).
         """
         LocalFourPoint.__init__(
@@ -399,8 +399,8 @@ class FourPoint(IAmNonLocal, LocalFourPoint):
 
         :param other: A :class:`FourPoint`, :class:`LocalFourPoint`, :class:`Interaction`, :class:`LocalInteraction`,
             numpy array, or number.
-        :param copy: If True (default), return a new :class:`FourPoint`; if False, accumulate into ``self`` in place
-            (only supported when ``other`` is a conforming :class:`FourPoint`, see :meth:`_add`).
+        :param copy: If True (default), return a new :class:`FourPoint`; if False, accumulate into ``self`` in place and
+            return ``self`` (only supported when ``other`` is a conforming :class:`FourPoint`, see :meth:`_add`).
         :return: A new :class:`FourPoint` holding the sum (or ``self`` when ``copy=False``).
         """
         return self._add(other, copy=copy)
@@ -908,13 +908,13 @@ class FourPoint(IAmNonLocal, LocalFourPoint):
 
         :param filename: Path to the ``.npy`` file (loaded with ``allow_pickle=False``).
         :param channel: Spin channel of the object (see :class:`SpinChannel`).
-        :param nq: Number of momenta per spatial direction.
-        :param num_wn_dimensions: Number of bosonic frequency axes (0–1).
-        :param num_vn_dimensions: Number of fermionic frequency axes (0–2).
-        :param full_niw_range: Whether the stored array spans the full (signed) bosonic range or only :math:`\omega \geq 0`.
-        :param full_niv_range: Whether the stored array spans the full (signed) fermionic range or only :math:`\nu \geq 0`.
-        :param has_compressed_q_dimension: Whether the momentum is stored as a single compressed axis (True) or as
-            ``[qx, qy, qz, ...]`` (False).
+        :param nq: Number of momenta per spatial direction ``(nx, ny, nz)``.
+        :param num_wn_dimensions: Number of bosonic frequency axes (0 or 1).
+        :param num_vn_dimensions: Number of fermionic frequency axes (0, 1 or 2).
+        :param full_niw_range: Whether the object spans the full (signed) bosonic range or only :math:`\omega \geq 0`.
+        :param full_niv_range: Whether the object spans the full (signed) fermionic range or only :math:`\nu \geq 0`.
+        :param has_compressed_q_dimension: Whether the momentum is stored as a single compressed axis ``[q, ...]``
+            (True) or as three separate axes ``[qx, qy, qz, ...]`` (False).
         :param frequency_notation: Frequency convention (see :class:`FrequencyNotation`).
         :return: The loaded :class:`FourPoint`.
         """
@@ -948,7 +948,7 @@ class FourPoint(IAmNonLocal, LocalFourPoint):
         :param niw: Number of positive bosonic frequencies.
         :param niv: Number of positive fermionic frequencies.
         :param nq_tot: Total number of momenta (product over directions).
-        :param nq: Number of momenta per spatial direction.
+        :param nq: Number of momenta per spatial direction ``(nx, ny, nz)``.
         :param num_vn_dimensions: Number of fermionic frequency axes (1 or 2).
         :param frequency_notation: Frequency convention (see :class:`FrequencyNotation`).
         :return: The identity :class:`FourPoint` (compressed momentum, half niw range).

--- a/dgamore/gap_function.py
+++ b/dgamore/gap_function.py
@@ -33,7 +33,7 @@ class GapFunction(TwoPoint, IHaveChannel):
 
         :param mat: Gap-function array with one momentum dimension, two orbital axes and one fermionic frequency axis.
         :param channel: Pairing channel, i.e. singlet or triplet (see :class:`SpinChannel`).
-        :param nk: Number of momenta per spatial direction ``(nkx, nky, nkz)``.
+        :param nk: Number of k-points per spatial direction ``(nx, ny, nz)``.
         :param full_niv_range: Whether the object spans the full (signed) fermionic range or only
             :math:`\nu \geq 0`.
         :param has_compressed_q_dimension: Whether the momentum is stored as a single compressed axis ``[q, ...]``

--- a/dgamore/greens_function.py
+++ b/dgamore/greens_function.py
@@ -177,7 +177,7 @@ class GreensFunction(TwoPoint):
             filling/occupation, exposed via the :attr:`n`, :attr:`occ` and :attr:`occ_k` properties.
         :param has_compressed_q_dimension: Whether the momentum is stored as a single compressed axis ``[q, ...]``
             (True) or as three separate axes ``[kx, ky, kz, ...]`` (False).
-        :param nk: Number of momenta per spatial direction ``(nkx, nky, nkz)``.
+        :param nk: Number of k-points per spatial direction ``(nx, ny, nz)``.
         :param beta: Inverse temperature :math:`\beta`.
         :param mu: Chemical potential :math:`\mu`.
         """
@@ -378,7 +378,7 @@ class GreensFunction(TwoPoint):
 
         :param smom0: Zeroth self-energy moment :math:`\Sigma_\infty`, shape ``[o1, o2]``.
         :param smom1: First self-energy tail coefficient :math:`\Sigma_1`, shape ``[o1, o2]``.
-        :param niv: Number of positive fermionic frequencies in the box.
+        :param niv: Number of positive fermionic frequencies.
         :param beta: Inverse temperature :math:`\beta`.
         :return: The model tail contribution to the potential energy (real scalar, not yet divided by ``nk_tot``).
         """

--- a/dgamore/interaction.py
+++ b/dgamore/interaction.py
@@ -206,7 +206,7 @@ class Interaction(IAmNonLocal, LocalInteraction):
 
         :param mat: Interaction tensor :math:`V_{1234}^q` with one momentum dimension and four orbital axes.
         :param channel: Spin channel the tensor is expressed in (see :class:`SpinChannel`).
-        :param nq: Number of momenta per spatial direction ``(nqx, nqy, nqz)``.
+        :param nq: Number of momenta per spatial direction ``(nx, ny, nz)``.
         :param has_compressed_q_dimension: Whether the momentum is stored as a single compressed axis ``[q, ...]``
             (True) or as three separate axes ``[qx, qy, qz, ...]`` (False).
         """

--- a/dgamore/local_four_point.py
+++ b/dgamore/local_four_point.py
@@ -41,11 +41,11 @@ class LocalFourPoint(LocalNPoint, IHaveChannel):
 
         :param mat: Underlying array with four leading orbital axes followed by the frequency axes.
         :param channel: Spin channel of the object (see :class:`SpinChannel`).
-        :param num_wn_dimensions: Number of bosonic frequency axes (0–1).
-        :param num_vn_dimensions: Number of fermionic frequency axes (0–2).
+        :param num_wn_dimensions: Number of bosonic frequency axes (0 or 1).
+        :param num_vn_dimensions: Number of fermionic frequency axes (0, 1 or 2).
         :param full_niw_range: Whether the object spans the full (signed) bosonic range or only :math:`\omega \geq 0`.
         :param full_niv_range: Whether the object spans the full (signed) fermionic range or only :math:`\nu \geq 0`.
-        :param frequency_notation: Frequency convention (ph/ph_bar/pp; see :class:`FrequencyNotation`).
+        :param frequency_notation: Frequency convention (see :class:`FrequencyNotation`).
         """
         LocalNPoint.__init__(
             self,
@@ -617,8 +617,8 @@ class LocalFourPoint(LocalNPoint, IHaveChannel):
 
         :param other: A :class:`LocalFourPoint`, :class:`LocalInteraction`, numpy array, or number.
         :param copy: If True (default), return a new :class:`LocalFourPoint`; if False, accumulate into ``self`` in
-            place (only supported for conforming :class:`LocalFourPoint` and :class:`LocalInteraction` operands,
-            see :meth:`_add`).
+            place and return ``self`` (only supported for conforming :class:`LocalFourPoint` and
+            :class:`LocalInteraction` operands, see :meth:`_add`).
         :return: The sum (a new :class:`LocalFourPoint`, ``self`` when ``copy=False``, or a raw numpy array for a
             non-local :class:`Interaction`).
         """
@@ -778,8 +778,9 @@ class LocalFourPoint(LocalNPoint, IHaveChannel):
         Objects will always be returned in the half niw range to save memory.
 
         :param other: A :class:`LocalFourPoint`, :class:`LocalInteraction`, numpy array, or number.
-        :param copy: If True (default), return a new :class:`LocalFourPoint`; if False, subtract into ``self`` in
-            place and return ``self`` (see :meth:`_add` for the supported operands).
+        :param copy: If True (default), return a new :class:`LocalFourPoint`; if False, subtract into ``self`` in place
+            and return ``self`` (only supported for conforming :class:`LocalFourPoint` and :class:`LocalInteraction`
+            operands, see :meth:`_add`).
         :return: The difference, implemented as ``self._add(other, subtract=True)`` (see :meth:`_add`).
         :raises ValueError: Propagated from :meth:`_add` for unsupported operands.
         """
@@ -994,10 +995,10 @@ class LocalFourPoint(LocalNPoint, IHaveChannel):
 
         :param filename: Path to the ``.npy`` file (loaded with ``allow_pickle=False``).
         :param channel: Spin channel of the object (see :class:`SpinChannel`).
-        :param num_wn_dimensions: Number of bosonic frequency axes (0–1).
-        :param num_vn_dimensions: Number of fermionic frequency axes (0–2).
-        :param full_niw_range: Whether the stored array spans the full (signed) bosonic range or only :math:`\omega \geq 0`.
-        :param full_niv_range: Whether the stored array spans the full (signed) fermionic range or only :math:`\nu \geq 0`.
+        :param num_wn_dimensions: Number of bosonic frequency axes (0 or 1).
+        :param num_vn_dimensions: Number of fermionic frequency axes (0, 1 or 2).
+        :param full_niw_range: Whether the object spans the full (signed) bosonic range or only :math:`\omega \geq 0`.
+        :param full_niv_range: Whether the object spans the full (signed) fermionic range or only :math:`\nu \geq 0`.
         :param frequency_notation: Frequency convention (see :class:`FrequencyNotation`).
         :return: The loaded :class:`LocalFourPoint`.
         """
@@ -1028,8 +1029,8 @@ class LocalFourPoint(LocalNPoint, IHaveChannel):
         :param n_bands: Number of orbitals/bands per orbital axis.
         :param niw: Number of positive bosonic frequencies.
         :param niv: Number of positive fermionic frequencies.
-        :param num_wn_dimensions: Number of bosonic frequency axes (0–1).
-        :param num_vn_dimensions: Number of fermionic frequency axes (0–2).
+        :param num_wn_dimensions: Number of bosonic frequency axes (0 or 1).
+        :param num_vn_dimensions: Number of fermionic frequency axes (0, 1 or 2).
         :param channel: Spin channel of the object (see :class:`SpinChannel`).
         :param frequency_notation: Frequency convention (see :class:`FrequencyNotation`).
         :param value: Constant fill value.

--- a/dgamore/local_n_point.py
+++ b/dgamore/local_n_point.py
@@ -41,8 +41,8 @@ class LocalNPoint(IHaveMat):
         :param num_orbital_dimensions: Number of orbital axes; 2 (two-point) or 4 (three-/four-leg vertex).
         :param num_wn_dimensions: Number of bosonic frequency axes (0 or 1).
         :param num_vn_dimensions: Number of fermionic frequency axes (0, 1 or 2).
-        :param full_niw_range: Whether the bosonic axis spans the full (signed) range or only :math:`\omega \geq 0`.
-        :param full_niv_range: Whether the fermionic axes span the full (signed) range or only :math:`\nu \geq 0`.
+        :param full_niw_range: Whether the object spans the full (signed) bosonic range or only :math:`\omega \geq 0`.
+        :param full_niv_range: Whether the object spans the full (signed) fermionic range or only :math:`\nu \geq 0`.
         """
         IHaveMat.__init__(self, mat)
 

--- a/dgamore/matsubara_frequencies.py
+++ b/dgamore/matsubara_frequencies.py
@@ -43,7 +43,7 @@ class MFHelper:
         Returns the integer bosonic Matsubara indices in the closed interval :math:`[-\mathrm{niw}, \mathrm{niw}]`,
         optionally shifted. This is the index-only overload (no temperature dependence).
 
-        :param niw: Half-width of the bosonic frequency box (number of positive bosonic frequencies).
+        :param niw: Number of positive bosonic frequencies.
         :param shift: Integer offset added to the whole index range.
         :param return_only_positive: If True, return only the non-negative indices :math:`[0, \mathrm{niw}]`.
         :return: 1D integer array of bosonic Matsubara indices.
@@ -59,7 +59,7 @@ class MFHelper:
         Returns the real bosonic Matsubara frequencies :math:`\omega_n = 2 n \pi / \beta` for the index range
         :math:`n \in [-\mathrm{niw}, \mathrm{niw}]`, optionally shifted.
 
-        :param niw: Half-width of the bosonic frequency box (number of positive bosonic frequencies).
+        :param niw: Number of positive bosonic frequencies.
         :param beta: Inverse temperature :math:`\beta`.
         :param shift: Integer offset added to the whole index range before scaling.
         :param return_only_positive: If True, return only the non-negative frequencies.
@@ -75,7 +75,7 @@ class MFHelper:
         :math:`[-\mathrm{niv}, \mathrm{niv})`, optionally shifted. This is the index-only overload (no temperature
         dependence).
 
-        :param niv: Half-width of the fermionic frequency box (number of positive fermionic frequencies).
+        :param niv: Number of positive fermionic frequencies.
         :param shift: Integer offset added to the whole index range.
         :param return_only_positive: If True, return only the non-negative indices :math:`[0, \mathrm{niv})`.
         :return: 1D integer array of fermionic Matsubara indices.
@@ -91,7 +91,7 @@ class MFHelper:
         Returns the real fermionic Matsubara frequencies :math:`\nu_n = (2 n + 1) \pi / \beta` for the index range
         :math:`n \in [-\mathrm{niv}, \mathrm{niv})`, optionally shifted.
 
-        :param niv: Half-width of the fermionic frequency box (number of positive fermionic frequencies).
+        :param niv: Number of positive fermionic frequencies.
         :param beta: Inverse temperature :math:`\beta`.
         :param shift: Integer offset added to the whole index range before scaling.
         :param return_only_positive: If True, return only the positive frequencies.

--- a/dgamore/mpi_utils.py
+++ b/dgamore/mpi_utils.py
@@ -878,7 +878,7 @@ def _send_in_chunks(comm, arr, dest, base_tag=0):
     :param comm: The MPI communicator.
     :param arr: The array to send.
     :param dest: Destination rank.
-    :param base_tag: Base MPI tag; successive chunks add the chunk index.
+    :param base_tag: Base MPI tag; successive chunks use ``base_tag + chunk_index``.
     :return: None.
     """
     send_rows(comm, arr, dest, base_tag=base_tag, limit=MAX_MPI_BYTES)
@@ -893,7 +893,7 @@ def _recv_in_chunks(comm, shape, dtype, source, base_tag=0):
     :param shape: Shape of the array to receive.
     :param dtype: Dtype of the array to receive.
     :param source: Source rank.
-    :param base_tag: Base MPI tag; successive chunks add the chunk index.
+    :param base_tag: Base MPI tag; successive chunks use ``base_tag + chunk_index``.
     :return: The received array.
     """
     return recv_rows_alloc(comm, shape, dtype, source, base_tag=base_tag, limit=MAX_MPI_BYTES)
@@ -1183,7 +1183,7 @@ def get_pencil_indices(rank: int, size: int, nq: tuple[int, int, int], layout: s
 
     :param rank: The rank whose indices to compute.
     :param size: Total number of ranks.
-    :param nq: The momentum grid sizes ``(nx, ny, nz)``.
+    :param nq: Number of momenta per spatial direction ``(nx, ny, nz)``.
     :param layout: One of ``"flat"``, ``"z_pencil"``, ``"y_pencil"``, ``"x_pencil"``.
     :return: The global flattened q-indices owned by ``rank``.
     :raises ValueError: If ``layout`` is not one of the supported layouts.
@@ -1260,7 +1260,7 @@ def _redistribute_p2p(mat, nq, comm, source_layout, target_layout):
     exchanging only the rows each rank pair shares (in below-2 GB byte chunks).
 
     :param mat: The local array slice, with the q-index on axis 0.
-    :param nq: The momentum grid sizes ``(nx, ny, nz)``.
+    :param nq: Number of momenta per spatial direction ``(nx, ny, nz)``.
     :param comm: The MPI communicator.
     :param source_layout: The current layout of ``mat`` (see :func:`get_pencil_indices`).
     :param target_layout: The desired layout of the result.

--- a/dgamore/n_point_base.py
+++ b/dgamore/n_point_base.py
@@ -429,7 +429,7 @@ class IHaveChannel(ABC):
         Stores the spin channel and frequency notation of the object.
 
         :param channel: Spin channel of the object (see :class:`SpinChannel`).
-        :param frequency_notation: Frequency notation of the object (see :class:`FrequencyNotation`).
+        :param frequency_notation: Frequency convention (see :class:`FrequencyNotation`).
         """
         self._channel = channel
         self._frequency_notation = frequency_notation
@@ -512,7 +512,7 @@ class IAmNonLocal(IHaveMat, ABC):
         Stores the array, the momentum-grid size and the momentum-layout flag.
 
         :param mat: The underlying numpy array with one (compressed) or three (decompressed) leading momentum axes.
-        :param nq: Number of momenta per spatial direction ``(nqx, nqy, nqz)``.
+        :param nq: Number of momenta per spatial direction ``(nx, ny, nz)``.
         :param has_compressed_q_dimension: Whether the momentum is stored as a single compressed axis ``[q, ...]``
             (True) or as three separate axes ``[qx, qy, qz, ...]`` (False).
         """

--- a/dgamore/nonlocal_sde.py
+++ b/dgamore/nonlocal_sde.py
@@ -1062,7 +1062,7 @@ def _run_fft_sde_pass(
     a single full-BZ niw half is ever resident.
 
     :param kernel_src: The irreducible-BZ kernel for this pass; consumed by the full-BZ map (mutated or replaced).
-    :param mpi_dist_irrk: MPI distributor over the irreducible BZ q-points.
+    :param mpi_dist_irrk: MPI distributor over the irreducible BZ q-points (see :class:`MpiDistributor`).
     :param mpi_dist_fullbz: MPI distributor over the full BZ q-points.
     :param g_r_local: This rank's real-space Green's function pencil from :func:`_build_rspace_giwk_pencil`, built
         once by the caller and reused by both passes.
@@ -1243,7 +1243,7 @@ def _build_giwk_full(comm: MPI.Comm, sigma: SelfEnergy, mu: float, ek: np.ndarra
     :func:`dgamore.mpi_utils.build_node_shared_array`). Otherwise every rank builds its own copy. The node topology is
     discovered at runtime via ``comm.Split_type(MPI.COMM_TYPE_SHARED)`` (nothing about the cluster is hard-coded).
 
-    :param comm: The (world) MPI communicator.
+    :param comm: The MPI communicator.
     :param sigma: The self-energy :math:`\Sigma` entering the Dyson equation.
     :param mu: Chemical potential :math:`\mu`.
     :param ek: Band dispersion :math:`\varepsilon(k)`.
@@ -1358,14 +1358,14 @@ def calculate_sigma_proposal(
     ``config.sys.occ`` / ``occ_k``, which the caller sets consistently with :math:`\Sigma_{\mathrm{in}}`.
 
     :param sigma_in: The input self-energy (full-BZ or local first-iteration, DMFT tail attached).
-    :param mu: The chemical potential the Green's function is built with.
+    :param mu: Chemical potential :math:`\mu`.
     :param u_loc: The bare local interaction :math:`U`.
     :param v_nonloc: The non-local interaction :math:`V^{q}`, reduced to this rank's irreducible q-points.
     :param v_nonloc_full: The non-local interaction on the full q-grid (for the Hartree/Fock term).
     :param sigma_dmft: The DMFT self-energy (cut to the loop's niv), providing the high-frequency tail.
     :param delta_sigma: The DMFT-minus-local noise-removal term on the core box.
     :param my_irr_q_list: This rank's irreducible q-point list.
-    :param mpi_dist_irrk: MPI distributor over the irreducible BZ q-points.
+    :param mpi_dist_irrk: MPI distributor over the irreducible BZ q-points (see :class:`MpiDistributor`).
     :param mpi_dist_fullbz: MPI distributor over the full BZ.
     :param comm: The MPI communicator.
     :param current_iter: The current iteration number (the RPA susceptibility is saved only on iteration 1).

--- a/dgamore/self_energy.py
+++ b/dgamore/self_energy.py
@@ -45,7 +45,7 @@ class SelfEnergy(TwoPoint):
 
         :param mat: Underlying self-energy array (two orbital axes and one fermionic frequency axis, optionally
             preceded by momentum axes).
-        :param nk: Number of momenta per spatial direction ``(nkx, nky, nkz)``.
+        :param nk: Number of k-points per spatial direction ``(nx, ny, nz)``.
         :param full_niv_range: Whether the object spans the full (signed) fermionic range or only :math:`\nu \geq 0`.
         :param has_compressed_q_dimension: Whether the momentum is stored as a single compressed axis ``[q, ...]``
             (True) or as three separate axes ``[kx, ky, kz, ...]`` (False).

--- a/dgamore/symmetry_reduction.py
+++ b/dgamore/symmetry_reduction.py
@@ -88,7 +88,7 @@ def _M_preserves_grid(M, nk):
     ``N_i``.
 
     :param M: The candidate 3x3 integer matrix.
-    :param nk: The grid sizes ``(nx, ny, nz)``.
+    :param nk: Number of k-points per spatial direction ``(nx, ny, nz)``.
     :return: True if ``M`` preserves the grid.
     """
     Ns = list(nk)
@@ -105,7 +105,7 @@ def _grid_index_stack(nk):
     Returns the read-only ``(nx, ny, nz, 3)`` stack of k-grid integer coordinates. Cached per grid size so the
     per-M k-index maps do not rebuild the meshgrid (called thousands of times during symmetry discovery).
 
-    :param nk: The grid sizes ``(nx, ny, nz)``.
+    :param nk: Number of k-points per spatial direction ``(nx, ny, nz)``.
     :return: The integer coordinate stack (shared, not to be mutated by callers).
     """
     nx, ny, nz = nk
@@ -121,7 +121,7 @@ def _apply_M_to_kgrid_indices(M, nk):
     scaling for non-cubic grids).
 
     :param M: The 3x3 integer matrix acting on k-indices.
-    :param nk: The grid sizes ``(nx, ny, nz)``.
+    :param nk: Number of k-points per spatial direction ``(nx, ny, nz)``.
     :return: The flat-index permutation array of length ``nx*ny*nz``.
     """
     nx, ny, nz = nk
@@ -145,7 +145,7 @@ def _apply_M_to_points(M, coords, nk):
 
     :param M: The 3x3 integer matrix acting on k-indices.
     :param coords: Integer grid coordinates of shape ``(K, 3)``.
-    :param nk: The grid sizes ``(nx, ny, nz)``.
+    :param nk: Number of k-points per spatial direction ``(nx, ny, nz)``.
     :return: The flat indices of the mapped coordinates, shape ``(K,)``.
     """
     nx, ny, nz = nk
@@ -166,7 +166,7 @@ def _translate_kgrid(idx_map, q, nk):
 
     :param idx_map: An existing flat-index map over the k-grid.
     :param q: The integer translation vector ``(qx, qy, qz)``.
-    :param nk: The grid sizes ``(nx, ny, nz)``.
+    :param nk: Number of k-points per spatial direction ``(nx, ny, nz)``.
     :return: The translated flat-index map.
     """
     nx, ny, nz = nk
@@ -188,7 +188,7 @@ def _apply_M_to_ev_field(M, ev, nk, idx_map=None):
 
     :param M: The 3x3 integer matrix acting on k-indices.
     :param ev: The eigenvalue field of shape ``(nx, ny, nz, n_orb)``.
-    :param nk: The grid sizes ``(nx, ny, nz)``.
+    :param nk: Number of k-points per spatial direction ``(nx, ny, nz)``.
     :param idx_map: Optional precomputed flat-index map from :func:`_apply_M_to_kgrid_indices` for ``M``.
     :return: The transformed eigenvalue field, same shape as ``ev``.
     """
@@ -676,7 +676,7 @@ def _grid_action_bytes(M, q, nk):
 
     :param M: The 3x3 integer matrix.
     :param q: The integer translation vector.
-    :param nk: The grid sizes ``(nx, ny, nz)``.
+    :param nk: Number of k-points per spatial direction ``(nx, ny, nz)``.
     :return: The byte string encoding the resulting flat-index map.
     """
     key = (M.tobytes(), q.tobytes(), tuple(nk))
@@ -720,7 +720,7 @@ class _GroupElement:
         :param U: The orbital-space unitary (canonicalized up to a global phase).
         :param sigma: The antisymmetry sign (``+1`` or ``-1``).
         :param conj: Whether the operation is anti-unitary (complex conjugation).
-        :param nk: The grid sizes ``(nx, ny, nz)``.
+        :param nk: Number of k-points per spatial direction ``(nx, ny, nz)``.
         """
         self.M = np.asarray(M, dtype=np.int64)
         self.q = np.asarray(q, dtype=np.int64)
@@ -764,7 +764,7 @@ class _GroupElement:
         Builds the identity group element (identity matrix, zero translation, identity unitary, ``sigma=+1``).
 
         :param norb: Number of orbitals.
-        :param nk: The grid sizes ``(nx, ny, nz)``.
+        :param nk: Number of k-points per spatial direction ``(nx, ny, nz)``.
         :return: The identity :class:`_GroupElement`.
         """
         return _GroupElement(
@@ -778,7 +778,7 @@ def _compose(ga, gb, nk):
 
     :param ga: The outer group element.
     :param gb: The inner group element.
-    :param nk: The grid sizes ``(nx, ny, nz)``.
+    :param nk: Number of k-points per spatial direction ``(nx, ny, nz)``.
     :return: The composed :class:`_GroupElement`.
     """
     Ns = np.array(nk, dtype=np.int64)
@@ -796,7 +796,7 @@ def _inverse(g, nk):
     Computes the inverse of a group element.
 
     :param g: The group element to invert.
-    :param nk: The grid sizes ``(nx, ny, nz)``.
+    :param nk: Number of k-points per spatial direction ``(nx, ny, nz)``.
     :return: The inverse :class:`_GroupElement`.
     """
     Ns = np.array(nk, dtype=np.int64)
@@ -814,7 +814,7 @@ def _close_group(ops_raw, norb, nk, max_size=10000):
 
     :param ops_raw: The list of discovered operation dicts.
     :param norb: Number of orbitals.
-    :param nk: The grid sizes ``(nx, ny, nz)``.
+    :param nk: Number of k-points per spatial direction ``(nx, ny, nz)``.
     :param max_size: Maximum allowed group size before bailing out.
     :return: The closed set of :class:`_GroupElement`.
     """
@@ -845,7 +845,7 @@ def _g_action_on_kgrid(g, nk):
     Returns the flat-index map of a group element's combined ``(M, q)`` action on the k-grid.
 
     :param g: The group element.
-    :param nk: The grid sizes ``(nx, ny, nz)``.
+    :param nk: Number of k-points per spatial direction ``(nx, ny, nz)``.
     :return: The flat-index permutation array.
     """
     idx = _apply_M_to_kgrid_indices(g.M, nk)

--- a/dgamore/two_point.py
+++ b/dgamore/two_point.py
@@ -39,7 +39,7 @@ class TwoPoint(IAmNonLocal, LocalTwoPoint):
 
         :param mat: Underlying array (one momentum axis -- compressed or not -- then two orbital axes and one
             fermionic frequency axis).
-        :param nk: Number of momenta per spatial direction ``(nkx, nky, nkz)``.
+        :param nk: Number of k-points per spatial direction ``(nx, ny, nz)``.
         :param full_niv_range: Whether the object spans the full (signed) fermionic range or only :math:`\nu \geq 0`.
         :param has_compressed_q_dimension: Whether the momentum is stored as a single compressed axis ``[q, ...]``
             (True) or as three separate axes ``[kx, ky, kz, ...]`` (False).

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -273,7 +273,9 @@ symmetry, but ``"random"`` is sufficient most of the time. The pairing vertex in
 which can be skipped by setting ``include_local_part`` to ``False``; this is only advisable when s-wave symmetry is
 not expected, as these diagrams become relevant in that case. With ``symmetrize_degenerate_gaps`` enabled (the
 default), gap functions belonging to (near-)degenerate eigenvalues are orthogonalized with a Loewdin scheme and
-degenerate doublets are rotated to their mirror-adapted (:math:`p_x`/:math:`p_y`-like) partners.
+rotated to their mirror-adapted partners: single-axis (:math:`p_x`/:math:`p_y`/:math:`p_z`-like) and two-axis
+(:math:`d_{xy}`/:math:`d_{xz}`/:math:`d_{yz}`-like) modes are ordered by the momentum reflections they are odd
+under.
 
 The ``resolve_frequency_parity`` field controls whether the physical gap-symmetry sectors are returned. The
 unprojected eigensolver leaks onto the globally dominant eigenvector, mixing frequency-even and frequency-odd modes;

--- a/tests/test_eliashberg_solver.py
+++ b/tests/test_eliashberg_solver.py
@@ -18,6 +18,7 @@ from dgamore.eliashberg_solver import (
     _chi0_to_matmul_layout,
     _compute_once_per_node,
     _frequency_parity_sectors,
+    _orient_cluster_by_mirrors,
     _sector_log_label,
     gap_parity_diagnostics,
     _project_gap_to_sector,
@@ -857,6 +858,126 @@ def test_symmetrize_degenerate_gaps_skips_dependent_vectors():
     gaps = np.stack([px, px * (1 + 1e-15)], axis=1)
     fixed = symmetrize_degenerate_gaps(np.array([0.5, 0.5]), gaps, gap_shape)
     assert np.allclose(fixed, gaps, atol=1e-12)
+
+
+def _make_p_wave_triplet(nk: int = 4, n2: int = 4) -> tuple[np.ndarray, np.ndarray, np.ndarray, tuple]:
+    """Builds orthonormal p_x/p_y/p_z-like gap columns sin(k_i) g(v) on a small three-dimensional single-band grid."""
+    gap_shape = (nk, nk, nk, 1, 1, n2)
+    k = 2 * np.pi * np.arange(nk) / nk
+    g_v = np.linspace(1.0, 0.5, n2)
+    px = np.sin(k)[:, None, None, None, None, None] * g_v * np.ones(gap_shape)
+    py = np.sin(k)[None, :, None, None, None, None] * g_v * np.ones(gap_shape)
+    pz = np.sin(k)[None, None, :, None, None, None] * g_v * np.ones(gap_shape)
+    columns = [(c.ravel() / np.linalg.norm(c)).astype(np.complex128) for c in (px, py, pz)]
+    return columns[0], columns[1], columns[2], gap_shape
+
+
+def _mirror_axis_column(column: np.ndarray, gap_shape: tuple, axis: int) -> np.ndarray:
+    """Applies the single-axis mirror k_axis -> -k_axis to a flattened gap column."""
+    idx = (gap_shape[axis] - np.arange(gap_shape[axis])) % gap_shape[axis]
+    take = [slice(None)] * len(gap_shape)
+    take[axis] = idx
+    return column.reshape(gap_shape)[tuple(take)].ravel()
+
+
+def test_symmetrize_degenerate_gaps_recovers_triplet_partners():
+    """An oblique degenerate triplet is rotated to p_x/p_y/p_z partners ordered by the axis each one is odd under."""
+    px, py, pz, gap_shape = _make_p_wave_triplet()
+    rng = np.random.default_rng(7)
+    mix = rng.standard_normal((3, 3)) + 1j * rng.standard_normal((3, 3))
+    gaps = np.stack([px, py, pz], axis=1) @ mix
+    fixed = symmetrize_degenerate_gaps(np.array([0.5, 0.5, 0.5]), gaps, gap_shape)
+    assert np.allclose(fixed.conj().T @ fixed, np.eye(3), atol=1e-10)
+    for col, (parent, odd_axis) in enumerate(((px, 0), (py, 1), (pz, 2))):
+        assert abs(np.vdot(fixed[:, col], parent)) > 1 - 1e-10
+        for axis in range(3):
+            sign = -1.0 if axis == odd_axis else 1.0
+            assert np.allclose(_mirror_axis_column(fixed[:, col], gap_shape, axis), sign * fixed[:, col], atol=1e-10)
+
+
+def test_symmetrize_degenerate_gaps_triplet_is_idempotent():
+    """Applying the symmetrization twice to a degenerate triplet gives the same result as applying it once."""
+    px, py, pz, gap_shape = _make_p_wave_triplet()
+    rng = np.random.default_rng(11)
+    gaps = np.stack([px, py, pz], axis=1) @ (rng.standard_normal((3, 3)) + 1j * rng.standard_normal((3, 3)))
+    lambdas = np.array([0.6, 0.6, 0.6])
+    once = symmetrize_degenerate_gaps(lambdas, gaps, gap_shape)
+    twice = symmetrize_degenerate_gaps(lambdas, once, gap_shape)
+    assert np.allclose(once, twice, atol=1e-10)
+
+
+def _make_d_wave_triplet(nk: int = 4, n2: int = 4) -> tuple[np.ndarray, np.ndarray, np.ndarray, tuple]:
+    """Builds orthonormal d_xy/d_xz/d_yz-like gap columns sin(k_i) sin(k_j) g(v) on a small three-dimensional grid."""
+    gap_shape = (nk, nk, nk, 1, 1, n2)
+    s = np.sin(2 * np.pi * np.arange(nk) / nk)
+    g_v = np.linspace(1.0, 0.5, n2)
+    dxy = s[:, None, None, None, None, None] * s[None, :, None, None, None, None] * g_v * np.ones(gap_shape)
+    dxz = s[:, None, None, None, None, None] * s[None, None, :, None, None, None] * g_v * np.ones(gap_shape)
+    dyz = s[None, :, None, None, None, None] * s[None, None, :, None, None, None] * g_v * np.ones(gap_shape)
+    columns = [(c.ravel() / np.linalg.norm(c)).astype(np.complex128) for c in (dxy, dxz, dyz)]
+    return columns[0], columns[1], columns[2], gap_shape
+
+
+def test_symmetrize_degenerate_gaps_orders_two_axis_gaps_by_odd_axis_pair():
+    """A degenerate d_xy/d_xz/d_yz triplet is resolved and ordered by the pair of axes each partner is odd under."""
+    dxy, dxz, dyz, gap_shape = _make_d_wave_triplet()
+    rng = np.random.default_rng(7)
+    mix = rng.standard_normal((3, 3)) + 1j * rng.standard_normal((3, 3))
+    gaps = np.stack([dxy, dxz, dyz], axis=1) @ mix
+    fixed = symmetrize_degenerate_gaps(np.array([0.5, 0.5, 0.5]), gaps, gap_shape)
+    assert np.allclose(fixed.conj().T @ fixed, np.eye(3), atol=1e-10)
+    for col, (parent, odd_axes) in enumerate(((dxy, {0, 1}), (dxz, {0, 2}), (dyz, {1, 2}))):
+        assert abs(np.vdot(fixed[:, col], parent)) > 1 - 1e-10
+        for axis in range(3):
+            sign = -1.0 if axis in odd_axes else 1.0
+            assert np.allclose(_mirror_axis_column(fixed[:, col], gap_shape, axis), sign * fixed[:, col], atol=1e-10)
+
+
+def test_orient_cluster_by_mirrors_falls_back_for_non_mirror_cluster():
+    """_orient_cluster_by_mirrors returns None when the cluster vectors are not clean +/-1 mirror eigenstates."""
+    gap_shape = (4, 4, 4, 1, 1, 4)
+    rng = np.random.default_rng(3)
+    n = int(np.prod(gap_shape))
+    block, _ = np.linalg.qr(rng.standard_normal((n, 3)) + 1j * rng.standard_normal((n, 3)))
+    assert _orient_cluster_by_mirrors(block, gap_shape) is None
+
+
+def test_orient_cluster_by_mirrors_falls_back_without_resolved_axes():
+    """_orient_cluster_by_mirrors returns None on a single-k-point grid where no momentum axis is reflected."""
+    gap_shape = (1, 1, 1, 1, 1, 4)
+    block, _ = np.linalg.qr(np.random.default_rng(3).standard_normal((4, 3)) + 0j)
+    assert _orient_cluster_by_mirrors(block, gap_shape) is None
+
+
+def test_orient_cluster_by_mirrors_resolves_a_p_triplet_without_diagonal_mirrors():
+    """On a non-square grid the coordinate mirrors alone (no diagonal family) still resolve a p_x/p_y/p_z triplet."""
+    gap_shape = (4, 6, 5, 1, 1, 4)
+    s = [np.sin(2 * np.pi * np.arange(n) / n) for n in gap_shape[:3]]
+    g_v = np.linspace(1.0, 0.5, gap_shape[-1])
+    px = s[0][:, None, None, None, None, None] * g_v * np.ones(gap_shape)
+    py = s[1][None, :, None, None, None, None] * g_v * np.ones(gap_shape)
+    pz = s[2][None, None, :, None, None, None] * g_v * np.ones(gap_shape)
+    cols = [(c.ravel() / np.linalg.norm(c)).astype(np.complex128) for c in (px, py, pz)]
+    rng = np.random.default_rng(2)
+    block, _ = np.linalg.qr(np.stack(cols, axis=1) @ (rng.standard_normal((3, 3)) + 1j * rng.standard_normal((3, 3))))
+    fixed = _orient_cluster_by_mirrors(block, gap_shape)
+    assert fixed is not None
+    for col, odd_axis in enumerate((0, 1, 2)):
+        for axis in range(3):
+            sign = -1.0 if axis == odd_axis else 1.0
+            assert np.allclose(_mirror_axis_column(fixed[:, col], gap_shape, axis), sign * fixed[:, col], atol=1e-10)
+
+
+def test_symmetrize_degenerate_gaps_canonicalizes_diagonal_p_doublet_to_axis_basis():
+    """An obliquely mixed p_{x+y}/p_{x-y} doublet is canonicalized to the coordinate p_x/p_y basis by the M_y mirror."""
+    px, py, gap_shape = _make_p_wave_doublet()
+    pxy = (px + py) / np.linalg.norm(px + py)
+    pxmy = (px - py) / np.linalg.norm(px - py)
+    rng = np.random.default_rng(9)
+    gaps = np.stack([pxy, pxmy], axis=1) @ (rng.standard_normal((2, 2)) + 1j * rng.standard_normal((2, 2)))
+    fixed = symmetrize_degenerate_gaps(np.array([0.5, 0.5]), gaps, gap_shape)
+    assert abs(np.vdot(fixed[:, 0], px)) > 1 - 1e-10
+    assert abs(np.vdot(fixed[:, 1], py)) > 1 - 1e-10
 
 
 def _assemble_two_atom_system(niv_pp: int, beta: float) -> tuple:


### PR DESCRIPTION
Symmetrization of gaps now also for 3D systems and triple-degenerate eigenvalues (e.g. px, py and pz).